### PR TITLE
Implement initial api and auth objects

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
 from pykube import HTTPClient, KubeConfig, all  # noqa
+from ._api import Kr8sApi
 
 __version__ = "0.0.0"

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
 from pykube import HTTPClient, KubeConfig, all  # noqa
-from ._api import Kr8sApi
+from ._api import Kr8sApi  # noqa
 
 __version__ = "0.0.0"

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -1,7 +1,6 @@
-import aiohttp
-import tempfile
 import ssl
 
+import aiohttp
 
 from ._auth import KubeAuth
 

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -36,6 +36,7 @@ class Kr8sApi:
             headers=headers,
             auth=userauth,
         )
+        # TODO close the session on exit
 
     async def get_version(self) -> dict:
         """Get the Kubernetes version"""

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -1,0 +1,49 @@
+import aiohttp
+import tempfile
+import ssl
+
+
+from ._auth import KubeAuth
+
+
+class Kr8sApi:
+    """A kr8s object for interacting with the Kubernetes API"""
+
+    def __init__(self, url=None, kubeconfig=None, serviceaccount=None) -> None:
+        from . import __version__
+
+        self.auth = KubeAuth(
+            url=url, kubeconfig=kubeconfig, serviceaccount=serviceaccount
+        )
+        self.sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        headers = {"User-Agent": f"kr8s/{__version__}"}
+        if self.auth.client_key_file:
+            self.sslcontext.load_cert_chain(
+                certfile=self.auth.client_cert_file,
+                keyfile=self.auth.client_key_file,
+                password=None,
+            )
+
+        if self.auth.server_ca_file:
+            self.sslcontext.load_verify_locations(cafile=self.auth.server_ca_file)
+        if self.auth.token:
+            headers["Authorization"] = f"Bearer {self.auth.token}"
+        userauth = None
+        if self.auth.username and self.auth.password:
+            userauth = aiohttp.BasicAuth(self.auth.username, self.auth.password)
+        self.session = aiohttp.ClientSession(
+            base_url=self.auth.server,
+            headers=headers,
+            auth=userauth,
+        )
+
+    async def get_version(self) -> dict:
+        """Get the Kubernetes version"""
+        return await self.call_api(method="GET", base="/version")
+
+    async def call_api(self, method, version: str = "", base: str = "") -> dict:
+        """Make a Kubernetes API request."""
+        async with self.session.request(
+            method=method, url=f"{base}", ssl=self.sslcontext
+        ) as response:
+            return await response.json()

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -1,5 +1,4 @@
 import ssl
-import tempfile
 
 import aiohttp
 

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -1,8 +1,9 @@
-import os
 import base64
-import yaml
+import os
 import tempfile
 from pathlib import Path
+
+import yaml
 
 
 class KubeAuth:
@@ -36,7 +37,7 @@ class KubeAuth:
         else:
             if serviceaccount:
                 self.load_service_account()
-            if kubeconfig != False:
+            if kubeconfig is not False:
                 self.load_kubeconfig()
 
     def load_kubeconfig(self):

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
 import os
+import subprocess
 import time
 
 import pytest
@@ -30,3 +31,13 @@ def k8s_cluster(request):
     del os.environ["KUBECONFIG"]
     if not request.config.getoption("keep_cluster"):
         kind_cluster.delete()
+
+
+@pytest.fixture
+async def kubectl_proxy(k8s_cluster):
+    proxy = subprocess.Popen(
+        [k8s_cluster.kubectl_path, "proxy"],
+        env={**os.environ, "KUBECONFIG": str(k8s_cluster.kubeconfig_path)},
+    )
+    yield "http://localhost:8001"
+    proxy.kill()

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
+
+from kr8s import Kr8sApi
+
+
+async def test_api():
+    kubernetes = Kr8sApi()
+    version = await kubernetes.get_version()
+    assert "major" in version

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
+from kr8s import Kr8sApi
+
+
+async def test_kubeconfig(k8s_cluster):
+    kubernetes = Kr8sApi(kubeconfig=k8s_cluster.kubeconfig_path)
+    version = await kubernetes.get_version()
+    assert "major" in version
+
+
+async def test_url(kubectl_proxy):
+    kubernetes = Kr8sApi(url=kubectl_proxy)
+    version = await kubernetes.get_version()
+    assert "major" in version

--- a/poetry.lock
+++ b/poetry.lock
@@ -805,4 +805,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8048702a9da66958ab1b8d6fc00f6ba7c2c1221ebd588f41b951809af296f576"
+content-hash = "a113f7072bc70a913cc957a3bfb7656726b6f762f1740d06dcda4efbd32b3e58"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ files = ["kr8s/__init__.py"]
 python = "^3.8"
 aiohttp = "^3.8.4"
 pykube-ng = "^22.9.0"
+pyyaml = "^6.0"
 
 
 [tool.poetry.group.test.dependencies]
@@ -49,7 +50,7 @@ pytest-rerunfailures = "^11.1.2"
 [tool.pytest.ini_options]
 addopts = "-v --keep-cluster --durations=10"
 timeout = 300
-reruns = 5
+reruns = 0
 reruns_delay = 1
 asyncio_mode = "auto"
 


### PR DESCRIPTION
Create `kr8s.Kr8sApi` which has initial support for authenticating and communicating with the Kubernetes API with `aiohttp`.

Supported auth mechanisms:
- URL (for use with `kubectl proxy`)
- Certificate auth (loaded from `kubeconfig`)
- Token auth (loaded from `kubeconfig`)
- Username/password (loaded from `kubeconfig`)
- Token auth (loaded from service account)

