### PR TITLE
Add service account tests

### DIFF
--- a/kr8s/_testutils.py
+++ b/kr8s/_testutils.py
@@ -1,0 +1,26 @@
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def set_env(**environ):
+    """
+    Temporarily set the process environment variables.
+
+    >>> with set_env(PLUGINS_DIR=u'test/plugins'):
+    ...   "PLUGINS_DIR" in os.environ
+    True
+
+    >>> "PLUGINS_DIR" in os.environ
+    False
+
+    :type environ: dict[str, unicode]
+    :param environ: Environment variables to set
+    """
+    old_environ = dict(os.environ)
+    os.environ.update(environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)

--- a/kr8s/tests/resources/serviceaccount.yaml
+++ b/kr8s/tests/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pytest

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -1,5 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
+from pathlib import Path
+
+import pytest
+
 from kr8s import Kr8sApi
 
 
@@ -13,3 +17,19 @@ async def test_url(kubectl_proxy):
     kubernetes = Kr8sApi(url=kubectl_proxy)
     version = await kubernetes.get_version()
     assert "major" in version
+
+
+async def test_no_config():
+    with pytest.raises(ValueError):
+        Kr8sApi(kubeconfig="/no/file/here")
+
+
+async def test_service_account(serviceaccount):
+    kubernetes = Kr8sApi(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
+
+    serviceaccount = Path(serviceaccount)
+    assert kubernetes.auth.server
+    assert kubernetes.auth.token == (serviceaccount / "token").read_text()
+    assert str(serviceaccount) in kubernetes.auth.server_ca_file
+    assert "BEGIN CERTIFICATE" in Path(kubernetes.auth.server_ca_file).read_text()
+    assert kubernetes.auth.namespace == (serviceaccount / "namespace").read_text()

--- a/kr8s/tests/test_testutils.py
+++ b/kr8s/tests/test_testutils.py
@@ -1,0 +1,20 @@
+import os
+
+from kr8s._testutils import set_env
+
+
+def test_set_env():
+    assert "FOO" not in os.environ
+    with set_env(FOO="bar"):
+        assert "FOO" in os.environ
+    assert "FOO" not in os.environ
+
+    os.environ["FOO"] = "bar"
+    assert "FOO" in os.environ
+    assert os.environ["FOO"] == "bar"
+    with set_env(FOO="baz"):
+        assert "FOO" in os.environ
+        assert os.environ["FOO"] == "baz"
+    assert "FOO" in os.environ
+    assert os.environ["FOO"] == "bar"
+    del os.environ["FOO"]


### PR DESCRIPTION
- Add a fixture to set up a fake service account using the credentials from the kubeconfig.
- Add test for service account auth.