### PR TITLE
Add API factory for caching API objects with same kwargs

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_api_resources.py
+++ b/examples/kubectl-ng/kubectl_ng/_api_resources.py
@@ -68,7 +68,7 @@ async def api_resources(
         kubectl-ng api-resources --api-group=rbac.authorization.k8s.io
 
     """
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     categories = [c.strip() for c in categories.split(",")] if categories else None
     verbs = [v.strip() for v in verbs.split(",")] if verbs else None
 

--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -78,7 +78,7 @@ async def get(
     Use "kubectl-ng api-resources" for a complete list of supported resources.
     """
     resources = resources[1:]
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     if all_namespaces:
         namespace = kr8s.ALL
     if "pods" in resources or "pod" in resources:

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
-from ._api import Kr8sApi, ALL  # noqa
+from ._api import Kr8sApi, ALL, api  # noqa
 from ._exceptions import NotFoundError  # noqa
 
 __version__ = "0.0.0"

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -7,9 +7,10 @@ from typing import Any, Optional
 import aiohttp
 from aiohttp import ClientResponse
 
-from ._api import Kr8sApi
-from ._data_utils import list_dict_unpack
-from ._exceptions import NotFoundError
+import kr8s
+from kr8s._api import Kr8sApi
+from kr8s._data_utils import list_dict_unpack
+from kr8s._exceptions import NotFoundError
 
 
 class APIObject:
@@ -23,8 +24,7 @@ class APIObject:
         """Initialize an APIObject."""
         # TODO support passing pykube or kubernetes objects in addition to dicts
         self.raw = resource
-        # TODO discover existing Kr8sApi object if one exists
-        self.api = api or Kr8sApi()
+        self.api = api or kr8s.api()
 
     def __repr__(self):
         """Return a string representation of the Kubernetes resource."""
@@ -92,7 +92,7 @@ class APIObject:
     ) -> "APIObject":
         """Get a Kubernetes resource by name."""
 
-        api = api or Kr8sApi()
+        api = api or kr8s.api()
         try:
             resources = await api.get(cls.endpoint, name, namespace=namespace, **kwargs)
             [resource] = resources

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -6,15 +6,49 @@ import kr8s
 from kr8s.objects import Pod
 
 
+async def test_api_factory(serviceaccount):
+    k1 = kr8s.api()
+    k2 = kr8s.api()
+    assert k1 is k2
+
+    k3 = kr8s.api(serviceaccount=serviceaccount)
+    k4 = kr8s.api(serviceaccount=serviceaccount)
+    assert k1 is not k3
+    assert k3 is k4
+
+    p = Pod({})
+    assert p.api is k1
+    assert p.api is not k3
+
+
+async def test_api_factory_with_kubeconfig(k8s_cluster, serviceaccount):
+    k1 = kr8s.api(kubeconfig=k8s_cluster.kubeconfig_path)
+    k2 = kr8s.api(serviceaccount=serviceaccount)
+    k3 = kr8s.api()
+    assert k1 is not k2
+    assert k3 is k1
+    assert k3 is not k2
+
+    p = Pod({})
+    assert p.api is k1
+
+    p2 = Pod({}, api=k2)
+    assert p2.api is k2
+
+    p3 = Pod({}, api=k3)
+    assert p3.api is k3
+    assert p3.api is not k2
+
+
 async def test_version():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     version = await kubernetes.version()
     assert "major" in version
 
 
 @pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system"])
 async def test_get_pods(namespace):
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     pods = await kubernetes.get("pods", namespace=namespace)
     assert isinstance(pods, list)
     assert len(pods) > 0
@@ -22,13 +56,13 @@ async def test_get_pods(namespace):
 
 
 async def test_get_deployments():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     deployments = await kubernetes.get("deployments")
     assert isinstance(deployments, list)
 
 
 async def test_api_resources():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     resources = await kubernetes.api_resources()
 
     names = [r["name"] for r in resources]

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from kr8s import Kr8sApi
+import kr8s
 from kr8s._testutils import set_env
 
 HERE = Path(__file__).parent.resolve()
@@ -38,25 +38,25 @@ async def kubeconfig_with_exec(k8s_cluster):
 
 
 async def test_kubeconfig(k8s_cluster):
-    kubernetes = Kr8sApi(kubeconfig=k8s_cluster.kubeconfig_path)
+    kubernetes = kr8s.api(kubeconfig=k8s_cluster.kubeconfig_path)
     version = await kubernetes.version()
     assert "major" in version
 
 
 async def test_url(kubectl_proxy):
-    kubernetes = Kr8sApi(url=kubectl_proxy)
+    kubernetes = kr8s.api(url=kubectl_proxy)
     version = await kubernetes.version()
     assert "major" in version
 
 
 async def test_no_config():
     with pytest.raises(ValueError):
-        kubernetes = Kr8sApi(kubeconfig="/no/file/here")
+        kubernetes = kr8s.api(kubeconfig="/no/file/here")
         await kubernetes.version()
 
 
 async def test_service_account(serviceaccount):
-    kubernetes = Kr8sApi(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
+    kubernetes = kr8s.api(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
     await kubernetes.version()
 
     serviceaccount = Path(serviceaccount)
@@ -68,6 +68,6 @@ async def test_service_account(serviceaccount):
 
 
 async def test_exec(kubeconfig_with_exec):
-    kubernetes = Kr8sApi(kubeconfig=kubeconfig_with_exec)
+    kubernetes = kr8s.api(kubeconfig=kubeconfig_with_exec)
     version = await kubernetes.version()
     assert "major" in version

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -101,7 +101,7 @@ async def test_pod_create_and_delete(example_pod_spec):
 
 
 async def test_list_and_ensure():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     pods = await kubernetes.get("pods", namespace=kr8s.ALL)
     assert len(pods) > 0
     for pod in pods:
@@ -171,7 +171,7 @@ async def test_patch_pod(example_pod_spec):
 
 
 async def test_all_v1_objects_represented():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     objects = await kubernetes.api_resources()
     supported_apis = (
         "v1",
@@ -231,7 +231,7 @@ async def test_deployment_scale(example_deployment_spec):
 
 
 async def test_node():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     nodes = await kubernetes.get("nodes")
     assert len(nodes) > 0
     for node in nodes:
@@ -242,7 +242,7 @@ async def test_node():
 
 
 async def test_service_proxy():
-    kubernetes = kr8s.Kr8sApi()
+    kubernetes = kr8s.api()
     [service] = await kubernetes.get("services", "kubernetes")
     assert service.name == "kubernetes"
     data = await service.proxy_http_get("/version", raise_for_status=False)


### PR DESCRIPTION
Switch best practice for creating a `Kr8sApi` object to using the factory `kr8s.api()` which allows for some caching.

- Calling `kr8s.api()` for the first time, regardless of kwargs will return a new instance of `Kr8sApi`.
- Calling again with the same kwargs will return the same object.
- Calling again with different kwargs will return a new object.
- Calling with no kwargs will return the first instance if one exists.