### PR TITLE
Rename kr8s.Kr8sApi => kr8s.Api

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -11,8 +11,8 @@ version = await api.version()
 print(version)
 ```
 
-```{note}
-Calling [](#kr8s.api) returns an instance of [](#kr8s.Api). In most use cases the API client should be thought of as a singleton due to [client caching](#client-caching).
+```{tip}
+Calling [](#kr8s.api) returns a cached instance of [](#kr8s.Api). In most use cases [](#kr8s.api) should be thought of as a singleton due to [client caching](#client-caching).
 ```
 
 The client API is inspired by `kubectl` rather than the Kubernetes API directly as it's more likely that developers will be familiar with `kubectl`.

--- a/docs/client.md
+++ b/docs/client.md
@@ -12,7 +12,7 @@ print(version)
 ```
 
 ```{note}
-Calling [](#kr8s.api) returns an instance of [](#kr8s._api.Kr8sApi). We do not recommend instantiating this object directly and encourage you to use the [](#kr8s.api) factory function in order to benefit from [client caching](#client-caching).
+Calling [](#kr8s.api) returns an instance of [](#kr8s._api.Api). We do not recommend instantiating this object directly and encourage you to use the [](#kr8s.api) factory function in order to benefit from [client caching](#client-caching).
 ```
 
 The client API is inspired by `kubectl` rather than the Kubernetes API directly as it's more likely that developers will be familiar with `kubectl`.
@@ -29,7 +29,7 @@ for pod in pods:
 
 ## Low-level API calls
 
-For situations where there may not be an appropriate method to call or you want to call the Kubernetes API directly you can use the [`api.call_api`](#kr8s.Kr8sApi.call_api) context manager.
+For situations where there may not be an appropriate method to call or you want to call the Kubernetes API directly you can use the [`api.call_api`](#kr8s.Api.call_api) context manager.
 
 To make API requests for resources more convenience `call_api` allows building the url via various kwargs.
 

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
-from ._api import Kr8sApi, ALL, api  # noqa
+from ._api import Api, ALL, api  # noqa
 from ._exceptions import NotFoundError  # noqa
 
 __version__ = "0.0.0"

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -26,6 +26,12 @@ class Api(object):
     _instances = weakref.WeakValueDictionary()
 
     def __init__(self, **kwargs) -> None:
+        if not kwargs.pop("bypass_factory", False):
+            raise ValueError(
+                "Use kr8s.api() to get an instance of Api. "
+                "See https://docs.kr8s.org/en/latest/client.html#client-caching."
+            )
+
         self._url = kwargs.get("url")
         self._kubeconfig = kwargs.get("kubeconfig")
         self._serviceaccount = kwargs.get("serviceaccount")
@@ -247,7 +253,7 @@ def api(url=None, kubeconfig=None, serviceaccount=None, namespace=None) -> Api:
             return Api._instances[key]
         if all(k is None for k in kwargs.values()) and list(Api._instances.values()):
             return list(Api._instances.values())[0]
-        return Api(**kwargs)
+        return Api(**kwargs, bypass_factory=True)
 
     return _f(
         url=url,

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -14,8 +14,14 @@ from ._auth import KubeAuth
 ALL = "all"
 
 
-class Kr8sApi(object):
-    """A kr8s object for interacting with the Kubernetes API"""
+class Api(object):
+    """A kr8s object for interacting with the Kubernetes API.
+
+    .. warning::
+        This class is not intended to be instantiated directly. Instead, use the
+        :func:`kr8s.api` function to get a singleton instance of the API.
+
+    """
 
     _instances = weakref.WeakValueDictionary()
 
@@ -31,7 +37,7 @@ class Kr8sApi(object):
             serviceaccount=self._serviceaccount,
             namespace=kwargs.get("namespace"),
         )
-        Kr8sApi._instances[frozenset(kwargs.items())] = self
+        Api._instances[frozenset(kwargs.items())] = self
 
     async def _create_session(self):
         headers = {"User-Agent": self.__version__, "content-type": "application/json"}
@@ -229,21 +235,19 @@ class Kr8sApi(object):
         return f"kr8s/{__version__}"
 
 
-def api(url=None, kubeconfig=None, serviceaccount=None, namespace=None) -> Kr8sApi:
-    """Create a kr8s object for interacting with the Kubernetes API.
+def api(url=None, kubeconfig=None, serviceaccount=None, namespace=None) -> Api:
+    """Create a :class:`kr8s.Api` object for interacting with the Kubernetes API.
 
     If a kr8s object already exists with the same arguments, it will be returned.
     """
 
     def _f(**kwargs):
         key = frozenset(kwargs.items())
-        if key in Kr8sApi._instances:
-            return Kr8sApi._instances[key]
-        if all(k is None for k in kwargs.values()) and list(
-            Kr8sApi._instances.values()
-        ):
-            return list(Kr8sApi._instances.values())[0]
-        return Kr8sApi(**kwargs)
+        if key in Api._instances:
+            return Api._instances[key]
+        if all(k is None for k in kwargs.values()) and list(Api._instances.values()):
+            return list(Api._instances.values())[0]
+        return Api(**kwargs)
 
     return _f(
         url=url,

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -21,6 +21,8 @@ class Api(object):
         This class is not intended to be instantiated directly. Instead, use the
         :func:`kr8s.api` function to get a singleton instance of the API.
 
+        See https://docs.kr8s.org/en/latest/client.html#client-caching.
+
     """
 
     _instances = weakref.WeakValueDictionary()

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -8,7 +8,7 @@ import aiohttp
 from aiohttp import ClientResponse
 
 import kr8s
-from kr8s._api import Kr8sApi
+from kr8s._api import Api
 from kr8s._data_utils import list_dict_unpack
 from kr8s._exceptions import NotFoundError
 
@@ -20,7 +20,7 @@ class APIObject:
     scalable = False
     scalable_spec = "replicas"
 
-    def __init__(self, resource: dict, api: Kr8sApi = None) -> None:
+    def __init__(self, resource: dict, api: Api = None) -> None:
         """Initialize an APIObject."""
         # TODO support passing pykube or kubernetes objects in addition to dicts
         self._raw = resource
@@ -97,7 +97,7 @@ class APIObject:
 
     @classmethod
     async def get(
-        cls, name: str, namespace: str = None, api: Kr8sApi = None, **kwargs
+        cls, name: str, namespace: str = None, api: Api = None, **kwargs
     ) -> "APIObject":
         """Get a Kubernetes resource by name."""
 
@@ -739,7 +739,7 @@ def get_class(kind, version=None):
     raise KeyError(f"No object registered for {version}/{kind}")
 
 
-def object_from_spec(spec: dict, api: Kr8sApi = None) -> APIObject:
+def object_from_spec(spec: dict, api: Api = None) -> APIObject:
     """Create an APIObject from a Kubernetes resource spec.
 
     Args:

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -8,6 +8,14 @@ import kr8s
 from kr8s.objects import Pod
 
 
+async def test_factory_bypass():
+    with pytest.raises(ValueError, match="kr8s.api()"):
+        _ = kr8s.Api()
+        assert not kr8s.Api._instances
+    _ = kr8s.api()
+    assert kr8s.Api._instances
+
+
 async def test_api_factory(serviceaccount):
     k1 = kr8s.api()
     k2 = kr8s.api()


### PR DESCRIPTION
Renaming the `kr8s.Kr8sApi` class to `kr8s.Api` to try and add a little more consistency with the `kr8s.api` factory function.

As we improve docs we will want to refer to methods on `kr8s.Api` directly and I generally want users to consider `kr8s.api` and `kr8s.Api` to be equivalent and I don't want the name `Kr8sApi` to cause confusion.

In 99% of cases, users should create an API client using the `kr8s.api` function (or not at all if they want to just use the object API with default auth lookup). Also in most cases, we want to treat the API client like a singleton and this factory function handles the caching.

Users may want multiple clients if they are interacting with multiple clusters, which `kr8s.api` supports by using its kwargs as cache keys. 

In some rare cases, users may want to create an API client and avoid the cache. Perhaps they are using env vars to select the `kubeconfig` file or set the context. In which case they can call `kr8s.Api` directly. But this should be clearly documented as an advanced route.

I've updated `Api.__init__()` to raise if it is invoked directly and point folks towards docs on using the client caching. In those rare cases they can set `kr8s.Api(bypass_factory=True)`. But my goal here is to cater to the 99% while not blocking the 1%.