### PR TITLE
Revert nest-asyncio

### DIFF
--- a/kr8s/_asyncio.py
+++ b/kr8s/_asyncio.py
@@ -7,10 +7,6 @@ import functools
 import inspect
 from typing import Any, AsyncGenerator, Callable, Generator, Tuple
 
-import nest_asyncio
-
-nest_asyncio.apply()
-
 
 def _get_event_loop() -> asyncio.AbstractEventLoop:
     try:

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -57,6 +57,7 @@ def test_version_sync():
     assert "major" in version
 
 
+@pytest.mark.xfail(reason="Cannot run nested event loops", raises=RuntimeError)
 async def test_version_sync_in_async():
     kubernetes = kr8s.api()
     version = kubernetes.version()

--- a/poetry.lock
+++ b/poetry.lock
@@ -906,18 +906,6 @@ testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=7,<8)", "pytest-cov", 
 testing-docutils = ["pygments", "pytest (>=7,<8)", "pytest-param-files (>=0.3.4,<0.4.0)"]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.5.6"
-description = "Patch asyncio to allow nested event loops"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "nest_asyncio-1.5.6-py3-none-any.whl", hash = "sha256:b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8"},
-    {file = "nest_asyncio-1.5.6.tar.gz", hash = "sha256:d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290"},
-]
-
-[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -1726,4 +1714,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "bb8e1dd36d3b060bcd412571a976efc1c9adb41d48dc2937460d2f093989623a"
+content-hash = "17da29eb656a2129ac5b97c9afa01db6dae0341bb6cfb00a924eb194ce25c70c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ python = "^3.8"
 aiohttp = "^3.8.4"
 pyyaml = "^6.0"
 asyncio-atexit = "^1.0.1"
-nest-asyncio = "^1.5.6"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Revert #42 

Adding `nest-asyncio` has caused #43 which is more painful than not having sync in asyncio. Reverting for now and reopening #41 to track adding this ability back in.