### PR TITLE
Use the same API as kubectl to get a table

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import json
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from aiohttp import ClientResponse
@@ -826,6 +826,30 @@ class CustomResourceDefinition(APIObject):
     plural = "customresourcedefinitions"
     singular = "customresourcedefinition"
     namespaced = False
+
+
+## meta.k8s.io/v1 objects
+
+
+class Table(APIObject):
+    """A Kubernetes Table."""
+
+    version = "meta.k8s.io/v1"
+    endpoint = "tables"
+    kind = "Table"
+    plural = "tables"
+    singular = "table"
+    namespaced = False
+
+    @property
+    def rows(self) -> List[Dict]:
+        """Table rows."""
+        return self._raw["rows"]
+
+    @property
+    def column_definitions(self) -> List[Dict]:
+        """Table column definitions."""
+        return self._raw["columnDefinitions"]
 
 
 def get_class(kind, version=None, _asyncio=True):

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -34,4 +34,5 @@ from kr8s._objects import (  # noqa
     Service,
     ServiceAccount,
     StatefulSet,
+    Table,
 )

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -105,6 +105,9 @@ from ._objects import (
     StatefulSet as _StatefulSet,
 )
 from ._objects import (
+    Table as _Table,
+)
+from ._objects import (
     object_from_spec,  # noqa
 )
 
@@ -316,4 +319,10 @@ class Role(_Role):
 @sync
 class CustomResourceDefinition(_CustomResourceDefinition):
     __doc__ = _CustomResourceDefinition.__doc__
+    _asyncio = False
+
+
+@sync
+class Table(_Table):
+    __doc__ = _Table.__doc__
     _asyncio = False

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -6,7 +6,7 @@ import pytest
 
 import kr8s
 import kr8s.asyncio
-from kr8s.asyncio.objects import Pod
+from kr8s.asyncio.objects import Pod, Table
 
 
 async def test_factory_bypass():
@@ -84,6 +84,13 @@ async def test_get_pods(namespace):
     assert isinstance(pods, list)
     assert len(pods) > 0
     assert isinstance(pods[0], Pod)
+
+
+async def test_get_pods_as_table():
+    kubernetes = kr8s.asyncio.api()
+    pods = await kubernetes.get("pods", namespace="kube-system", as_object=Table)
+    assert isinstance(pods, Table)
+    assert len(pods.rows) > 0
 
 
 async def test_watch_pods(example_pod_spec):


### PR DESCRIPTION
So far the example `kubectl-ng get pods` grabs the list of Pods and does all of the formatting for the table client side.

Digging deeper into `kubectl` and the `api-machinery` it seems there is a `meta.k8s.io/v1` `Table` object which takes the place of a list of resources and returns a formatted table on the server side instead.

This PR adds the ability to call `kr8s.api.get(..., as=Type)` which sets the `Accept` header and allows you to tell the API server to return a different type. Also added the `meta.k8s.io/v1` `Table` type to `kr8s.objects`.

So by calling `kr8s.api.get("pods", as=kr8s.objects.Table)` we are setting `Accept: application/json;as=Table;v=v1;g=meta.k8s.io` when making a GET request for a list of Pods and getting a `Table` back instead of a `PodList`. 

Then I've refactored (and hugely simplified) the `kubectl-ng get <foo>` example to use this. This means we can now call get on any resource that is in the API. It also gets the list of API resources to enable the use of short names. It has broken some of the styling and CLI flags which will need to be added back at a later date.

```console
$ kubectl-ng get svc -A
                                                                                                  
  Namespace     Name         Type        Cluster-IP   External-IP   Port(s)                  Age  
 ──────────────────────────────────────────────────────────────────────────────────────────────── 
  default       kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP                  53d  
  kube-system   kube-dns     ClusterIP   10.96.0.10   <none>        53/UDP,53/TCP,9153/TCP   53d 
```