### PR TITLE
If sync API is used in a running loop start a new loop in a separate thread

### DIFF
--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -57,7 +57,6 @@ def test_version_sync():
     assert "major" in version
 
 
-@pytest.mark.xfail(reason="Cannot run nested event loops", raises=RuntimeError)
 async def test_version_sync_in_async():
     kubernetes = kr8s.api()
     version = kubernetes.version()


### PR DESCRIPTION
Closes #41 

Tweaked the async wrapping code originally taken from `universalasync` with an [implementation from `jupyter-core`](https://github.com/jupyter/jupyter_core/blob/98b9a1a94e79d1137246b4c1f8c16343b72b050c/jupyter_core/utils/__init__.py#L95) that starts a new loop on a separate thread if a loop is already running.

Now when using the sync API:
- If no loop is running it will run the coroutine with `asyncio.run`
- If a loop is already running (and paused because we are in a sync function) it will start a new thread with a new loop and run the coroutine there