### PR TITLE
Retry getting a resource until a timeout to avoid race conditions

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
+from __future__ import annotations
+
 import asyncio
 import json
 import time
@@ -116,9 +118,9 @@ class APIObject:
         name: str,
         namespace: str = None,
         api: Api = None,
-        timeout: int = 30,
+        timeout: int = 2,
         **kwargs,
-    ) -> "APIObject":
+    ) -> APIObject:
         """Get a Kubernetes resource by name."""
 
         if api is None:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import json
-from typing import Any, Dict, List, Optional
 import time
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from aiohttp import ClientResponse

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 from typing import Any, Dict, List, Optional
+import time
 
 import aiohttp
 from aiohttp import ClientResponse
@@ -111,7 +112,12 @@ class APIObject:
 
     @classmethod
     async def get(
-        cls, name: str, namespace: str = None, api: Api = None, **kwargs
+        cls,
+        name: str,
+        namespace: str = None,
+        api: Api = None,
+        timeout: int = 30,
+        **kwargs,
     ) -> "APIObject":
         """Get a Kubernetes resource by name."""
 
@@ -120,15 +126,22 @@ class APIObject:
                 api = await kr8s.asyncio.api()
             else:
                 api = kr8s.api()
-
-        resources = await api._get(cls.endpoint, name, namespace=namespace, **kwargs)
-        if len(resources) == 0:
-            raise NotFoundError(f"Could not find {cls.kind} {name}.")
-        if len(resources) > 1:
-            raise ValueError(
-                f"Expected exactly one {cls.kind} object. Use selectors to narrow down the search."
+        start = time.time()
+        backoff = 0.1
+        while start + timeout > time.time():
+            resources = await api._get(
+                cls.endpoint, name, namespace=namespace, **kwargs
             )
-        return resources[0]
+            if len(resources) == 0:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 1)
+                continue
+            if len(resources) > 1:
+                raise ValueError(
+                    f"Expected exactly one {cls.kind} object. Use selectors to narrow down the search."
+                )
+            return resources[0]
+        raise NotFoundError(f"Could not find {cls.kind} {name}.")
 
     async def exists(self, ensure=False) -> bool:
         """Check if this object exists in Kubernetes."""

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -173,6 +173,7 @@ async def test_pod_get_timeout(example_pod_spec):
 
     pods = await asyncio.gather(create_pod(), get_pod())
     assert pods[0].name == pods[1].name
+    await pods[0].delete()
 
 
 async def test_missing_pod():

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -156,6 +156,25 @@ async def test_pod_get(example_pod_spec):
         await pod2.delete()
 
 
+async def test_pod_get_timeout(example_pod_spec):
+    async def create_pod():
+        await asyncio.sleep(0.1)
+        pod = await Pod(example_pod_spec)
+        await pod.create()
+        return pod
+
+    async def get_pod():
+        pod = await Pod.get(
+            example_pod_spec["metadata"]["name"],
+            namespace=example_pod_spec["metadata"]["namespace"],
+            timeout=1,
+        )
+        return pod
+
+    pods = await asyncio.gather(create_pod(), get_pod())
+    assert pods[0].name == pods[1].name
+
+
 async def test_missing_pod():
     with pytest.raises(kr8s.NotFoundError):
         await Pod.get("nonexistant", namespace="default")


### PR DESCRIPTION
Currently, creating a resource and then immediately trying to get it may intermittently fail.

```python
from kr8s.objects import Pod

Pod({"metadata": {"name": "foo"}, ...}).create()
pod = Pod.get("foo")
```

This happens due to a race condition between the Kubernetes API server and kr8s.

To mitigate this problem this PR adds a retry to `APIObject.get` with a configurable timeout.