### PR TITLE
Add `kubectl-ng wait ...` and `APIObject.wait(...)`

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_wait.py
+++ b/examples/kubectl-ng/kubectl_ng/_wait.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
+import json
+import sys
+
+import typer
+import yaml
+from rich.console import Console
+from rich.syntax import Syntax
+from typing import List, Optional
+from typing_extensions import Annotated
+
+import kr8s
+
+console = Console()
+
+
+async def wait(
+    resources: Annotated[
+        Optional[List[str]], typer.Argument(..., help="TYPE[.VERSION][.GROUP]")
+    ] = None,
+    filename: str = typer.Option(
+        "",
+        "-f",
+        "--filename",
+        help="Filename, directory, or URL to files identifying the resource to wait on",
+    ),
+    label_selector: str = typer.Option(
+        "",
+        "-l",
+        "--selector",
+        help="Selector (label query) to filter on, supports '=', '==', and '!='. "
+        "(e.g. -l key1=value1,key2=value2). "
+        "Matching objects must satisfy all of the specified label constraints.",
+    ),
+):
+    if filename:
+        console.print("error: --filename is not supported yet")
+        raise typer.Exit(code=1)
+    console.print("Waiting...")

--- a/examples/kubectl-ng/kubectl_ng/_wait.py
+++ b/examples/kubectl-ng/kubectl_ng/_wait.py
@@ -11,7 +11,7 @@ from kr8s.asyncio.objects import APIObject, object_from_name_type
 
 console = Console()
 
-# Options
+# Missing Options
 # TODO --allow-missing-template-keys
 # TODO -f, --filename
 # TODO --local

--- a/examples/kubectl-ng/kubectl_ng/_wait.py
+++ b/examples/kubectl-ng/kubectl_ng/_wait.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import json
 import sys
+from typing import List, Optional
 
 import typer
 import yaml
 from rich.console import Console
 from rich.syntax import Syntax
-from typing import List, Optional
 from typing_extensions import Annotated
 
 import kr8s

--- a/examples/kubectl-ng/kubectl_ng/_wait.py
+++ b/examples/kubectl-ng/kubectl_ng/_wait.py
@@ -1,29 +1,49 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
-import json
-import sys
-from typing import List, Optional
+import asyncio
+from typing import List
 
 import typer
-import yaml
 from rich.console import Console
-from rich.syntax import Syntax
-from typing_extensions import Annotated
 
 import kr8s
+from kr8s.asyncio.objects import APIObject, object_from_name_type
 
 console = Console()
 
+# Examples
+# TODO kubectl delete pod/busybox1 && kubectl wait --for=delete pod/busybox1 --timeout=60s
+
+# Options
+# TODO --all
+# TODO -A, --all-namespaces
+# TODO --allow-missing-template-keys
+# TODO --field-selector
+# TODO -f, --filename
+# TODO --local
+# TODO -o, --output
+# TODO -R, --recursive
+# TODO -l, --selector
+# TODO --show-managed-fields
+# TODO --template
+# TODO --timeout
+
 
 async def wait(
-    resources: Annotated[
-        Optional[List[str]], typer.Argument(..., help="TYPE[.VERSION][.GROUP]")
-    ] = None,
+    resources: List[str] = typer.Argument(..., help="TYPE[.VERSION][.GROUP]"),
     filename: str = typer.Option(
         "",
-        "-f",
         "--filename",
         help="Filename, directory, or URL to files identifying the resource to wait on",
+    ),
+    conditions: List[str] = typer.Option(
+        [],
+        "-f",
+        "--for",
+        help="The condition to wait on: "
+        "[delete|condition=condition-name[=condition-value]|jsonpath='{JSONPath expression}'=JSONPath Condition]. "
+        "The default condition-value is true.  Condition values are compared after Unicode simple case folding, "
+        "which is a more general form of case-insensitivity.",
     ),
     label_selector: str = typer.Option(
         "",
@@ -33,8 +53,60 @@ async def wait(
         "(e.g. -l key1=value1,key2=value2). "
         "Matching objects must satisfy all of the specified label constraints.",
     ),
+    namespace: str = typer.Option(
+        None,
+        "-n",
+        "--namespace",
+        help="If present, the namespace scope for this CLI request",
+    ),
 ):
+    """Wait for a specific condition on one or many resources.
+
+    \b
+    The command takes multiple resources and waits until the specified condition is
+    seen in the Status field of every given resource.
+
+    \b
+    Alternatively, the command can wait for the given set of resources to be deleted
+    by providing the "delete" keyword as the value to the --for flag.
+
+    \b
+    A successful message will be printed to stdout indicating when the specified
+    condition has been met. You can use -o option to change to output destination.
+
+    \b
+    Examples:
+    \b
+        # Wait for the pod "busybox1" to contain the status condition of type "Ready"
+        kubectl wait --for=condition=Ready pod/busybox1
+
+    \b
+        # The default value of status condition is true; you can wait for other targets after an equal delimiter
+        # (compared after Unicode simple case folding, which is a more general form of case-insensitivity):
+        kubectl wait --for=condition=Ready=false pod/busybox1
+
+    \b
+        # Wait for the pod "busybox1" to contain the status phase to be "Running".
+        kubectl wait --for=jsonpath='{.status.phase}'=Running pod/busybox1
+
+    \b
+        # Wait for the pod "busybox1" to be deleted, with a timeout of 60s, after having issued the "delete" command
+        kubectl delete pod/busybox1
+        kubectl wait --for=delete pod/busybox1 --timeout=60s
+    """
     if filename:
         console.print("error: --filename is not supported yet")
         raise typer.Exit(code=1)
-    console.print("Waiting...")
+    try:
+        objects = await asyncio.gather(
+            *[object_from_name_type(r, namespace=namespace) for r in resources]
+        )
+    except kr8s.NotFoundError as e:
+        console.print("Error from server (NotFound): " + str(e))
+        raise typer.Exit(code=1)
+
+    async def wait_for(o: APIObject, conditions: List[str]):
+        await o.wait(conditions=conditions)
+        console.print(f"{o.singular}/{o.name} condition met")
+
+    await asyncio.gather(*[wait_for(o, conditions=conditions) for o in objects])

--- a/examples/kubectl-ng/kubectl_ng/cli.py
+++ b/examples/kubectl-ng/kubectl_ng/cli.py
@@ -8,6 +8,7 @@ import typer
 from ._api_resources import api_resources
 from ._get import get
 from ._version import version
+from ._wait import wait
 
 
 def _typer_async(f):
@@ -28,6 +29,7 @@ app = typer.Typer()
 register(app, api_resources)
 register(app, get)
 register(app, version)
+register(app, wait)
 
 
 def go():

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import json
-from typing import Any, Dict, List, Optional
+import re
+from typing import Any, Dict, List, Optional, Union
 
 import aiohttp
+import jsonpath
 from aiohttp import ClientResponse
 
 import kr8s
@@ -14,6 +16,8 @@ from kr8s._data_utils import list_dict_unpack
 from kr8s._exceptions import NotFoundError
 from kr8s.asyncio.portforward import PortForward as AsyncPortForward
 from kr8s.portforward import PortForward as SyncPortForward
+
+JSONPATH_CONDITION_EXPRESSION = r"jsonpath='{(?P<expression>.*?)}'=(?P<condition>.*)"
 
 
 class APIObject:
@@ -233,6 +237,49 @@ class APIObject:
         ):
             self.raw = obj.raw
             yield event, self
+
+    async def _test_conditions(self, conditions: Union[List[str], str]) -> bool:
+        """Test if conditions are met."""
+        if isinstance(conditions, str):
+            conditions = [conditions]
+        for condition in conditions:
+            if condition.startswith("condition"):
+                condition = "=".join(condition.split("=")[1:])
+                if "=" in condition:
+                    field, value = condition.split("=")
+                    value = str(value)
+                else:
+                    field = condition
+                    value = str(True)
+                if value == "true" or value == "false":
+                    value = value.title()
+                status_conditions = list_dict_unpack(
+                    self.status.get("conditions", []), "type", "status"
+                )
+                if status_conditions.get(field, None) != value:
+                    return False
+            elif condition == "delete":
+                if await self._exists():
+                    return False
+            elif condition.startswith("jsonpath"):
+                matches = re.search(JSONPATH_CONDITION_EXPRESSION, condition)
+                expression = matches.group("expression")
+                condition = matches.group("condition")
+                [value] = jsonpath.findall(expression, self._raw)
+                if value != condition:
+                    return False
+            else:
+                raise ValueError(f"Unknown condition type {condition}")
+        return True
+
+    async def wait(self, conditions: list):
+        """Wait for conditions to be met."""
+        await self._refresh()
+        if await self._test_conditions(conditions):
+            return
+        async for _ in self.watch():
+            if await self._test_conditions(conditions):
+                return
 
 
 ## v1 objects
@@ -890,3 +937,30 @@ def object_from_spec(spec: dict, api: Api = None) -> APIObject:
     """
     cls = get_class(spec["kind"], spec["apiVersion"])
     return cls(spec, api=api)
+
+
+async def object_from_name_type(
+    name: str, namespace: str = None, api: Api = None
+) -> APIObject:
+    """Create an APIObject from a Kubernetes resource name.
+
+    Args:
+        name: A Kubernetes resource name.
+
+    Returns:
+        A corresponding APIObject subclass instance.
+
+    Raises:
+        ValueError: If the resource kind or API version is not supported.
+    """
+    if "/" not in name:
+        raise ValueError(f"Invalid name: {name}. Expecting format of 'resource/name'.")
+    resource_type, name = name.split("/")
+    if "." in resource_type:
+        kind = resource_type.split(".")[0]
+        version = ".".join(resource_type.split(".")[1:])
+    else:
+        kind = resource_type
+        version = None
+    cls = get_class(kind, version)
+    return await cls.get(name, namespace=namespace, api=api)

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -35,4 +35,5 @@ from kr8s._objects import (  # noqa
     ServiceAccount,
     StatefulSet,
     Table,
+    object_from_name_type,
 )

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -1,4 +1,4 @@
-from ._asyncio import sync
+from ._asyncio import run_sync, sync
 from ._objects import (
     APIObject as _APIObject,
 )
@@ -107,9 +107,11 @@ from ._objects import (
 from ._objects import (
     Table as _Table,
 )
-from ._objects import (
-    object_from_spec,  # noqa
+from ._objects import (  # noqa
+    get_class,
+    object_from_spec,
 )
+from ._objects import object_from_name_type as _object_from_name_type
 
 
 @sync
@@ -326,3 +328,6 @@ class CustomResourceDefinition(_CustomResourceDefinition):
 class Table(_Table):
     __doc__ = _Table.__doc__
     _asyncio = False
+
+
+object_from_name_type = run_sync(_object_from_name_type)

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -99,6 +99,8 @@ async def test_pod_wait_ready(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()
     await pod.wait("condition=Ready")
+    with pytest.raises(asyncio.TimeoutError):
+        await pod.wait("jsonpath='{.status.phase}'=Foo", timeout=0.1)
     await pod.wait("condition=Ready=true")
     await pod.wait("condition=Ready=True")
     await pod.wait("jsonpath='{.status.phase}'=Running")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1739,4 +1739,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "c28164115f11ccad21a06f92c5a622669ecab55fd66e5007b946a168f418957d"
+content-hash = "d9835b968fe215ec6dfd29ee54bb101fa1a528520a8adcab46c01e52a0f67c3e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1093,6 +1093,18 @@ files = [
 pytest = ">=5.0.0"
 
 [[package]]
+name = "python-jsonpath"
+version = "0.7.1"
+description = "Another JSONPath implementation for Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python_jsonpath-0.7.1-py3-none-any.whl", hash = "sha256:12d2ec1d38547e495d7746fc185abc9f462369f9a7b2c1c66de92242e84eb362"},
+    {file = "python_jsonpath-0.7.1.tar.gz", hash = "sha256:5099d88e55d71314eac5d8b7acc528cb47d53783ba9685940da8fb63a7674b54"},
+]
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 description = "World timezone definitions, modern and historical"
@@ -1727,4 +1739,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e16131be38bb3a1e41a2409a21853cd77cbf018484b17a400e2cd4e4e57a5a58"
+content-hash = "c28164115f11ccad21a06f92c5a622669ecab55fd66e5007b946a168f418957d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pyyaml = "^6.0"
 asyncio-atexit = "^1.0.1"
 aiofiles = "^23.1.0"
 python-jsonpath = "^0.7.1"
+async-timeout = "^4.0.2"
 
 
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ aiohttp = "^3.8.4"
 pyyaml = "^6.0"
 asyncio-atexit = "^1.0.1"
 aiofiles = "^23.1.0"
+python-jsonpath = "^0.7.1"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Added support for waiting on resource conditions.

```console
$ kubectl-ng wait --for=condition=Ready --namespace kube-system pod/kindnet-dwg5q
pod/kindnet-dwg5q condition met
```

The same functionality is available from the Python API.

```python
Python 3.10.11 | packaged by conda-forge | (main, May 10 2023, 18:58:44) [GCC 11.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.10.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from kr8s.asyncio.objects import Pod

In [2]: p = await Pod.get("kindnet-dwg5q", namespace="kube-system")

In [3]: await p.wait("condition=Ready")  # Blocks until condition is true 
```