### PR TITLE
Bump Kubernetes support to include 1.27

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,14 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        kubernetes-version: ["1.25.0"]
+        kubernetes-version: ["1.27.0"]
         include:
         - python-version: "3.10"
-          kubernetes-version: "1.22.13"
+          kubernetes-version: "1.24.13"
         - python-version: "3.10"
-          kubernetes-version: "1.23.10"
+          kubernetes-version: "1.25.9"
         - python-version: "3.10"
-          kubernetes-version: "1.24.4"
+          kubernetes-version: "1.26.4"
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Read the Docs](https://img.shields.io/readthedocs/kr8s?logo=readthedocs&logoColor=white)](https://kr8s.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kr8s)](https://pypi.org/project/kr8s/)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.24%7C1.25%7C1.26%7C1.27-blue)](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,3 +5,8 @@ You can install kr8s from PyPI using `pip`.
 ```console
 $ pip install kr8s
 ```
+
+## Supported Kubernetes Versions
+
+We endeavor to support all Kubernetes versions that are [actively supported by the Kubernetes community](https://kubernetes.io/releases/).
+Kubernetes typically releases 3-4 times a year and provides 1 year of patch support.


### PR DESCRIPTION
Update CI matrix to include [currently supported Kubernetes versions](https://kubernetes.io/releases/).

Also add a badge and some docs about our support policy.