### PR TITLE
Implement instantiate objects from files

### DIFF
--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -36,4 +36,5 @@ from kr8s._objects import (  # noqa
     StatefulSet,
     Table,
     object_from_name_type,
+    objects_from_files,
 )

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -107,11 +107,9 @@ from ._objects import (
 from ._objects import (
     Table as _Table,
 )
-from ._objects import (  # noqa
-    get_class,
-    object_from_spec,
-)
+from ._objects import get_class, new_class, object_from_spec  # noqa
 from ._objects import object_from_name_type as _object_from_name_type
+from ._objects import objects_from_files as _objects_from_files
 
 
 @sync
@@ -331,3 +329,4 @@ class Table(_Table):
 
 
 object_from_name_type = run_sync(_object_from_name_type)
+objects_from_files = run_sync(_objects_from_files)

--- a/kr8s/tests/resources/custom/evc.yaml
+++ b/kr8s/tests/resources/custom/evc.yaml
@@ -1,0 +1,4 @@
+apiVersion: kopf.dev/v1
+kind: EphemeralVolumeClaim
+metadata:
+  name: my-claim

--- a/kr8s/tests/resources/simple/nested/nginx_ingress.yaml
+++ b/kr8s/tests/resources/simple/nested/nginx_ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx-example
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80

--- a/kr8s/tests/resources/simple/nginx_pod.yaml
+++ b/kr8s/tests/resources/simple/nginx_pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/kr8s/tests/resources/simple/nginx_pod_service.yaml
+++ b/kr8s/tests/resources/simple/nginx_pod_service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: proxy
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 80
+        name: http-web-svc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app.kubernetes.io/name: proxy
+  ports:
+  - name: name-of-service-port
+    protocol: TCP
+    port: 80
+    targetPort: http-web-svc


### PR DESCRIPTION
Implement a utility function for creating objects from YAML files. Intended for use in `kubectl-ng` commands that use the `-f` flag.

```yaml
# pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - name: nginx
    image: nginx:1.14.2
    ports:
    - containerPort: 80
```

```python
>>> from kr8s.objects import objects_from_files
>>> objs = objects_from_files("pod.yaml")
>>> objs
[<Pod nginx>]
>>> objs[0].name
'nginx'
>>> objs[0].spec["containers"][0]["image"]
'nginx:1.14.2'
```