### PR TITLE
Add Deployment.pods()

### DIFF
--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -50,3 +50,19 @@ def dot_to_nested_dict(dot_notated_key: str, value: Any) -> Dict:
         else:
             nested_dict = {key: nested_dict}
     return nested_dict
+
+
+def dict_to_selector(selector_dict: Dict) -> str:
+    """Convert a dictionary to a Kubernetes selector.
+
+    Parameters
+    ----------
+    selector_dict : Dict
+        The dictionary to convert to a Kubernetes selector.
+
+    Returns
+    -------
+    str
+        A Kubernetes selector string.
+    """
+    return ",".join(f"{k}={v}" for k, v in selector_dict.items())

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -664,7 +664,7 @@ class Service(APIObject):
 
     async def _ready_pods(self) -> List[Pod]:
         """Return a list of ready pods for this service."""
-        pod_selector = ",".join([f"{k}={v}" for k, v in self.labels.items()])
+        pod_selector = ",".join([f"{k}={v}" for k, v in self.spec["selector"].items()])
         pods = await self.api._get("pods", label_selector=pod_selector)
         return [pod for pod in pods if await pod.ready()]
 
@@ -737,6 +737,18 @@ class Deployment(APIObject):
     singular = "deployment"
     namespaced = True
     scalable = True
+
+    async def ready_pods(self) -> List[Pod]:
+        """Return a list of ready pods for this service."""
+        return await self._ready_pods()
+
+    async def _ready_pods(self) -> List[Pod]:
+        """Return a list of ready pods for this service."""
+        pod_selector = ",".join(
+            [f"{k}={v}" for k, v in self.spec["selector"]["matchLabels"].items()]
+        )
+        pods = await self.api._get("pods", label_selector=pod_selector)
+        return [pod for pod in pods if await pod.ready()]
 
     async def ready(self):
         """Check if the deployment is ready."""

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -659,11 +659,11 @@ class Service(APIObject):
         return await self._proxy_http_request("DELETE", path, port, **kwargs)
 
     async def ready_pods(self) -> List[Pod]:
-        """Return a list of ready pods for this service."""
+        """Return a list of ready Pods for this Service."""
         return await self._ready_pods()
 
     async def _ready_pods(self) -> List[Pod]:
-        """Return a list of ready pods for this service."""
+        """Return a list of ready Pods for this Service."""
         pod_selector = ",".join([f"{k}={v}" for k, v in self.spec["selector"].items()])
         pods = await self.api._get("pods", label_selector=pod_selector)
         return [pod for pod in pods if await pod.ready()]
@@ -738,17 +738,17 @@ class Deployment(APIObject):
     namespaced = True
     scalable = True
 
-    async def ready_pods(self) -> List[Pod]:
-        """Return a list of ready pods for this service."""
-        return await self._ready_pods()
+    async def pods(self) -> List[Pod]:
+        """Return a list of Pods for this Deployment."""
+        return await self._pods()
 
-    async def _ready_pods(self) -> List[Pod]:
-        """Return a list of ready pods for this service."""
+    async def _pods(self) -> List[Pod]:
+        """Return a list of Pods for this Deployment."""
         pod_selector = ",".join(
             [f"{k}={v}" for k, v in self.spec["selector"]["matchLabels"].items()]
         )
         pods = await self.api._get("pods", label_selector=pod_selector)
-        return [pod for pod in pods if await pod.ready()]
+        return pods
 
     async def ready(self):
         """Check if the deployment is ready."""

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -740,10 +740,6 @@ class Deployment(APIObject):
 
     async def pods(self) -> List[Pod]:
         """Return a list of Pods for this Deployment."""
-        return await self._pods()
-
-    async def _pods(self) -> List[Pod]:
-        """Return a list of Pods for this Deployment."""
         pod_selector = ",".join(
             [f"{k}={v}" for k, v in self.spec["selector"]["matchLabels"].items()]
         )

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
 
-from kr8s._data_utils import dot_to_nested_dict, list_dict_unpack
+from kr8s._data_utils import dict_to_selector, dot_to_nested_dict, list_dict_unpack
 
 
 def test_list_dict_unpack():
@@ -17,3 +17,8 @@ def test_dot_to_nested_dict():
             "bar": {"baz": "value"},
         }
     }
+
+
+def test_dict_to_selector():
+    assert dict_to_selector({"foo": "bar"}) == "foo=bar"
+    assert dict_to_selector({"foo": "bar", "baz": "qux"}) == "foo=bar,baz=qux"

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -337,6 +337,8 @@ async def test_deployment_scale(example_deployment_spec):
     assert deployment.replicas == 2
     while not await deployment.ready():
         await asyncio.sleep(0.1)
+    pods = await deployment.ready_pods()
+    assert len(pods) == 2
     await deployment.scale(1)
     assert deployment.replicas == 1
     await deployment.delete()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -337,7 +337,7 @@ async def test_deployment_scale(example_deployment_spec):
     assert deployment.replicas == 2
     while not await deployment.ready():
         await asyncio.sleep(0.1)
-    pods = await deployment.ready_pods()
+    pods = await deployment.pods()
     assert len(pods) == 2
     await deployment.scale(1)
     assert deployment.replicas == 1


### PR DESCRIPTION
Closes #78 

It looks like the service object already has `Service.ready_pods()` which is similar so I've added a version of that to `Deployment.pods()` but without checking if they are ready. It also looks like there was a bug in `Service.ready_pods()` so I've fixed that too.