### PR TITLE
Replace async-timeout with anyio.fail_after

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -10,10 +10,10 @@ import time
 from typing import Any, Dict, List, Optional, Type, Union
 
 import aiohttp
+import anyio
 import jsonpath
 import yaml
 from aiohttp import ClientResponse
-from async_timeout import timeout as async_timeout
 
 import kr8s
 import kr8s.asyncio
@@ -306,7 +306,7 @@ class APIObject:
         if isinstance(conditions, str):
             conditions = [conditions]
 
-        with async_timeout(timeout):
+        with anyio.fail_after(timeout):
             try:
                 await self._refresh()
             except NotFoundError:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -103,7 +103,7 @@ async def test_pod_wait_ready(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()
     await pod.wait("condition=Ready")
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         await pod.wait("jsonpath='{.status.phase}'=Foo", timeout=0.1)
     await pod.wait("condition=Ready=true")
     await pod.wait("condition=Ready=True")
@@ -119,7 +119,7 @@ def test_pod_wait_ready_sync(example_pod_spec):
     pod = SyncPod(example_pod_spec)
     pod.create()
     pod.wait("condition=Ready")
-    with pytest.raises(asyncio.TimeoutError):
+    with pytest.raises(TimeoutError):
         pod.wait("jsonpath='{.status.phase}'=Foo", timeout=0.1)
     pod.wait("condition=Ready=true")
     pod.wait("condition=Ready=True")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1911,4 +1911,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "af6ae4c70e0179ab92b9d413303135ebe6767a98638843f544729f5a83479228"
+content-hash = "7daf27f418016c1633d3255ea6bbd0ce34899fe02df3ee9751bf12c5a1a08a80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ aiohttp = "^3.8.4"
 pyyaml = "^6.0"
 asyncio-atexit = "^1.0.1"
 python-jsonpath = "^0.7.1"
-async-timeout = "^4.0.2"
 anyio = "^3.7.0"
 
 


### PR DESCRIPTION
In #83  we replaced `aiofiles` with `anyio`. Now instead of using `async-timeout` we can use `anyio.fail_after` to time things out in an async-library-agnostic way.

This PR updates the one place we use the timeout and removes the dependency. Also updated the tests because the exception has changed from `asyncio.TimeoutError` to the builtin `TimeoutError`.