### PR TITLE
Update run_sync shim to use anyio

### DIFF
--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -23,39 +23,3 @@ async def test_tempfiles():
         assert await f.exists()
         assert isinstance(f, anyio.Path)
     assert not await f.exists()
-
-
-async def test_anyio_sync_in_async():
-    def foo():
-        async def bar():
-            return "hello"
-
-        try:
-            return anyio.run(bar)
-        except RuntimeError:
-            with anyio.from_thread.start_blocking_portal() as portal:
-                return portal.call(bar)
-
-    assert await anyio.to_thread.run_sync(foo) == "hello"
-    assert foo() == "hello"
-
-
-def test_anyio_sync_in_sync():
-    def foo():
-        async def bar():
-            return "hello"
-
-        try:
-            return anyio.run(bar)
-        except RuntimeError:
-            with anyio.from_thread.start_blocking_portal() as portal:
-                return portal.call(bar)
-
-    assert foo() == "hello"
-
-
-def test_anyio_awaitable():
-    async def main():
-        pass
-
-    anyio.run(main)

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -23,3 +23,39 @@ async def test_tempfiles():
         assert await f.exists()
         assert isinstance(f, anyio.Path)
     assert not await f.exists()
+
+
+async def test_anyio_sync_in_async():
+    def foo():
+        async def bar():
+            return "hello"
+
+        try:
+            return anyio.run(bar)
+        except RuntimeError:
+            with anyio.from_thread.start_blocking_portal() as portal:
+                return portal.call(bar)
+
+    assert await anyio.to_thread.run_sync(foo) == "hello"
+    assert foo() == "hello"
+
+
+def test_anyio_sync_in_sync():
+    def foo():
+        async def bar():
+            return "hello"
+
+        try:
+            return anyio.run(bar)
+        except RuntimeError:
+            with anyio.from_thread.start_blocking_portal() as portal:
+                return portal.call(bar)
+
+    assert foo() == "hello"
+
+
+def test_anyio_awaitable():
+    async def main():
+        pass
+
+    anyio.run(main)


### PR DESCRIPTION
The current implementation of `kr8s._io.run_sync` uses `asyncio.run` to execute coroutines, and if that raises a `RuntimeError` because we are already in a loop it creates a new `asyncio.AbstractEventLoop` in a separate thread and uses that to execute the coroutine.

This PR updates things to instead use `anyio.from_thread.start_blocking_portal()` to create a new event loop in a separate thread in an async-agnostic way.

Closes #88