### PR TITLE
Fix default service account path

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -31,11 +31,13 @@ class KubeAuth:
         self._context = None
         self._cluster = None
         self._user = None
-        self._serviceaccount = anyio.Path(
+        self._serviceaccount = (
             serviceaccount
             if serviceaccount is not None
             else "/var/run/secrets/kubernetes.io/serviceaccount"
         )
+        if self._serviceaccount:
+            self._serviceaccount = anyio.Path(self._serviceaccount)
         self._kubeconfig = anyio.Path(
             kubeconfig or os.environ.get("KUBECONFIG", "~/.kube/config")
         )

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -138,16 +138,18 @@ class KubeAuth:
     async def _load_service_account(self) -> None:
         """Load credentials from service account."""
         self._serviceaccount = os.path.expanduser(self._serviceaccount)
-        if not await os.path.isdir(self._serviceaccount):
+        if not os.path.isdir(self._serviceaccount):
             return
         host = os.environ["KUBERNETES_SERVICE_HOST"]
         port = os.environ["KUBERNETES_SERVICE_PORT"]
         self.server = f"https://{host}:{port}"
-        async with anyio.open_file(os.path.join(self._serviceaccount, "token")) as f:
+        async with await anyio.open_file(
+            os.path.join(self._serviceaccount, "token")
+        ) as f:
             self.token = await f.read()
         self.server_ca_file = os.path.join(self._serviceaccount, "ca.crt")
         if self.namespace is None:
-            async with anyio.open_file(
+            async with await anyio.open_file(
                 os.path.join(self._serviceaccount, "namespace")
             ) as f:
                 self.namespace = await f.read()

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -33,7 +33,7 @@ class KubeAuth:
         self._user = None
         self._serviceaccount = anyio.Path(
             serviceaccount
-            if serviceaccount
+            if serviceaccount is not None
             else "/var/run/secrets/kubernetes.io/serviceaccount"
         )
         self._kubeconfig = anyio.Path(

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -17,7 +17,7 @@ class KubeAuth:
         self,
         kubeconfig=None,
         url=None,
-        serviceaccount="/var/run/secrets/kubernetes.io/serviceaccount",
+        serviceaccount=None,
         namespace=None,
     ) -> None:
         self.server = None
@@ -31,7 +31,11 @@ class KubeAuth:
         self._context = None
         self._cluster = None
         self._user = None
-        self._serviceaccount = anyio.Path(serviceaccount) if serviceaccount else None
+        self._serviceaccount = anyio.Path(
+            serviceaccount
+            if serviceaccount
+            else "/var/run/secrets/kubernetes.io/serviceaccount"
+        )
         self._kubeconfig = anyio.Path(
             kubeconfig or os.environ.get("KUBECONFIG", "~/.kube/config")
         )

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -44,6 +44,14 @@ async def test_kubeconfig(k8s_cluster):
     assert "major" in version
 
 
+async def test_default_service_account(k8s_cluster):
+    kubernetes = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
+    assert (
+        str(kubernetes.auth._serviceaccount)
+        == "/var/run/secrets/kubernetes.io/serviceaccount"
+    )
+
+
 async def test_reauthenticate(k8s_cluster):
     kubernetes = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
     await kubernetes.reauthenticate()

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -44,7 +44,6 @@ async def test_kubeconfig(k8s_cluster):
     assert "major" in version
 
 
-@pytest.mark.skip(reason="seems to be causing CI to hang")
 async def test_default_service_account(k8s_cluster):
     kubernetes = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
     assert (

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -44,6 +44,7 @@ async def test_kubeconfig(k8s_cluster):
     assert "major" in version
 
 
+@pytest.mark.skip(reason="seems to be causing CI to hang")
 async def test_default_service_account(k8s_cluster):
     kubernetes = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
     assert (


### PR DESCRIPTION
Looks like the default `serviceaccount` value was being overridden as `None`. Updated things to ensure the default value is set correctly.