### PR TITLE
Expose the namespace on the Api object

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -157,7 +157,7 @@ class Api(object):
         from ._objects import get_class
 
         if not namespace:
-            namespace = self.auth.namespace
+            namespace = self.namespace
         if namespace is ALL:
             namespace = ""
         if params is None:

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -320,3 +320,12 @@ class Api(object):
         from . import __version__
 
         return f"kr8s/{__version__}"
+
+    @property
+    def namespace(self) -> str:
+        """Get the default namespace."""
+        return self.auth.namespace
+
+    @namespace.setter
+    def namespace(self, value):
+        self.auth.namespace = value

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -76,9 +76,7 @@ class APIObject:
     def namespace(self) -> str:
         """Namespace of the Kubernetes resource."""
         if self.namespaced:
-            return self.raw.get("metadata", {}).get(
-                "namespace", self.api.auth.namespace
-            )
+            return self.raw.get("metadata", {}).get("namespace", self.api.namespace)
         return None
 
     @property

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -150,3 +150,11 @@ async def test_api_resources():
     assert deployment["version"] == "apps/v1"
     assert "get" in deployment["verbs"]
     assert "deploy" in deployment["shortNames"]
+
+
+async def test_ns(ns):
+    api = await kr8s.asyncio.api()
+    assert ns == api.namespace
+
+    api.namespace = "foo"
+    assert api.namespace == "foo"


### PR DESCRIPTION
```python
import kr8s
api = kr8s.api()
print(api.namespace)  # Prints "default" unless you've changed it in your config via a service account

api.namespace = "foo"
print(api.namespace)  # Prints "foo"
```

This makes it a little easier for folks to access this value and also set the default to something else before calling other methods.