### PR TITLE
Enable creating objects from name only

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -34,10 +34,17 @@ class APIObject:
     scalable_spec = "replicas"
     _asyncio = True
 
-    def __init__(self, resource: dict, api: Api = None) -> None:
+    def __init__(self, resource: dict, namespace: str = None, api: Api = None) -> None:
         """Initialize an APIObject."""
         # TODO support passing pykube or kubernetes objects in addition to dicts
-        self._raw = resource
+        if isinstance(resource, str):
+            self._raw = {"metadata": {"name": resource}}
+        elif isinstance(resource, dict):
+            self._raw = resource
+        else:
+            raise ValueError("resource must be a dict or a string")
+        if namespace is not None:
+            self._raw["metadata"]["namespace"] = namespace
         self.api = api
         if self.api is None and not self._asyncio:
             self.api = kr8s.api()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -206,6 +206,21 @@ async def test_pod_get(example_pod_spec):
         await pod2.delete()
 
 
+async def test_pod_from_name(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    pod2 = await Pod(
+        pod.name, namespace=pod.namespace
+    )  # Note: Does not call the Kubernetes API
+    assert pod2.name == pod.name
+    assert pod2.namespace == pod.namespace
+    await pod.delete()
+    while await pod.exists():
+        await asyncio.sleep(0.1)
+    with pytest.raises(kr8s.NotFoundError):
+        await pod2.delete()
+
+
 async def test_pod_get_timeout(example_pod_spec):
     async def create_pod():
         await asyncio.sleep(0.1)


### PR DESCRIPTION
Currently, you can get an object by name. Doing so makes a call to the Kubernetes API to get the latest state of the resource.

```python
import kr8s

pod = kr8s.objects.Pod.get("my-awesome-pod")
```

This PR adds the ability to create an unpopulated object which doesn't make the API call, this could be useful if you know a resource exists and you want to perform an operation like `patch`, `scale`, `delete`, etc without the initial API call.

```python
import kr8s

pod = kr8s.objects.Pod("my-awesome-pod")
```