### PR TITLE
Allow casting objects to dicts

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -316,6 +316,14 @@ class APIObject:
                 if await self._test_conditions(conditions):
                     return
 
+    def keys(self) -> list:
+        """Return the keys of this object."""
+        return self.raw.keys()
+
+    def __getitem__(self, key: str) -> Any:
+        """Get an item from this object."""
+        return self.raw[key]
+
 
 ## v1 objects
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -507,3 +507,4 @@ async def test_custom_object_from_file():
 async def test_pod_to_dict(example_pod_spec):
     pod = Pod(example_pod_spec)
     assert dict(pod) == example_pod_spec
+    assert dict(pod) == pod.raw

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -502,3 +502,8 @@ async def test_custom_object_from_file():
     simple_dir = CURRENT_DIR / "resources" / "custom" / "evc.yaml"
     objects = await objects_from_files(simple_dir)
     assert len(objects) == 1
+
+
+async def test_pod_to_dict(example_pod_spec):
+    pod = Pod(example_pod_spec)
+    assert dict(pod) == example_pod_spec


### PR DESCRIPTION
Closes #95 

```python
>>> from kr8s.objects import Pod
>>> pod = Pod({
...         "apiVersion": "v1",
...         "kind": "Pod",
...         "metadata": {
...             "name": "my-pod",
...         },
...         "spec": {
...             "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause",}]
...         },
...     })
>>> print(dict(pod))
{'apiVersion': 'v1', 'kind': 'Pod', 'metadata': {'name': 'my-pod'}, 'spec': {'containers': [{'name': 'pause', 'image': 'gcr.io/google_containers/pause'}]}}
```