### PR TITLE
Get object with selectors

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -347,12 +347,20 @@ class APIObject:
                 if await self._test_conditions(conditions):
                     return
 
-    async def annotate(self, annotations: dict) -> None:
+    async def annotate(self, annotations: dict = None, **kwargs) -> None:
         """Annotate this object in Kubernetes."""
+        if annotations is None:
+            annotations = kwargs
+        if not annotations:
+            raise ValueError("No annotations provided")
         await self._patch({"metadata": {"annotations": annotations}})
 
-    async def label(self, labels: dict) -> None:
+    async def label(self, labels: dict = None, **kwargs) -> None:
         """Label this object in Kubernetes."""
+        if labels is None:
+            labels = kwargs
+        if not labels:
+            raise ValueError("No labels provided")
         await self._patch({"metadata": {"labels": labels}})
 
     def keys(self) -> list:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -323,6 +323,14 @@ class APIObject:
                 if await self._test_conditions(conditions):
                     return
 
+    async def annotate(self, annotations: dict) -> None:
+        """Annotate this object in Kubernetes."""
+        await self._patch({"metadata": {"annotations": annotations}})
+
+    async def label(self, labels: dict) -> None:
+        """Label this object in Kubernetes."""
+        await self._patch({"metadata": {"labels": labels}})
+
     def keys(self) -> list:
         """Return the keys of this object."""
         return self.raw.keys()

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -65,6 +65,17 @@ class APIObject:
         """Return a string representation of the Kubernetes resource."""
         return self.name
 
+    def __eq__(self, other):
+        if self.version != other.version:
+            return False
+        if self.kind != other.kind:
+            return False
+        if self.name != other.name:
+            return False
+        if self.namespaced and self.namespace != other.namespace:
+            return False
+        return True
+
     @property
     def raw(self) -> str:
         """Raw object returned from the Kubernetes API."""

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -287,6 +287,22 @@ async def test_pod_watch(example_pod_spec):
     await pod.delete()
 
 
+async def test_pod_annotate(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    await pod.annotate({"foo": "bar"})
+    assert "foo" in pod.annotations
+    await pod.delete()
+
+
+async def test_pod_label(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    await pod.label({"foo": "bar"})
+    assert "foo" in pod.labels
+    await pod.delete()
+
+
 def test_pod_watch_sync(example_pod_spec):
     pod = SyncPod(example_pod_spec)
     pod.create()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -280,7 +280,7 @@ async def test_field_selector(example_pod_spec):
 async def test_get_with_label_selector(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()
-    await pod.label({"test": "test_get_with_label_selector"})
+    await pod.label(test="test_get_with_label_selector")
 
     pod2 = await Pod.get(label_selector=pod.labels)
     assert pod == pod2

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -283,7 +283,10 @@ async def test_get_with_label_selector(example_pod_spec):
     await pod.label({"test": "test_get_with_label_selector"})
 
     pod2 = await Pod.get(label_selector=pod.labels)
-    pod == pod2
+    assert pod == pod2
+
+    pod3 = await Pod.get(field_selector={"metadata.name": pod.name})
+    assert pod == pod3
 
     await pod.delete()
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -277,6 +277,17 @@ async def test_field_selector(example_pod_spec):
     await pod.delete()
 
 
+async def test_get_with_label_selector(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    await pod.label({"test": "test_get_with_label_selector"})
+
+    pod2 = await Pod.get(label_selector=pod.labels)
+    pod == pod2
+
+    await pod.delete()
+
+
 async def test_pod_watch(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()


### PR DESCRIPTION
In addition to getting an object with it's name this PR allows you to get an object via a selector.

```python
from kr8s.objects import Pod

pod = Pod.get(label_selector={"foo": "bar"})
```

This assumes only one Pod will be returned and if multiple Pods are found an exception will be raised.

To implement the tests for this I also made a couple of additional quality of life changes. First is labelling and annotation methods.

```python
pod = Pod.get("some-snazzy-pod")
pod.label({"hello": "world"})  # Adds the label hello=world via a patch request
pod.annotate({"foo": "bar"})  # Adds the annotation foo=bar via a patch request

# Also works with kwargs
pod.label(hello="world")
```

Then also added object equivalence checks

```python
pod = Pod.get("some-snazzy-pod")
pod2 = Pod.get(label_selector=pod.labels)

assert pod == pod2
```