### PR TITLE
Generate a new Kubernetes namespace for each test

### DIFF
--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -119,17 +119,17 @@ def k8s_cluster(request) -> KindCluster:
         kind_cluster.delete()
 
 
-@pytest.fixture(scope="session")
-def ns(k8s_cluster) -> str:
-    # Ideally we want to generate a random namespace for each test or suite, but
-    # this can make teardown very slow. So we just use the default namespace for now.
+@pytest.fixture(scope="session", autouse=True)
+def run_id():
+    return uuid.uuid4().hex[:4]
 
-    yield "default"
 
-    # name = "kr8s-pytest-" + uuid.uuid4().hex[:4]
-    # k8s_cluster.kubectl("create", "namespace", name)
-    # yield name
-    # k8s_cluster.kubectl("delete", "namespace", name)
+@pytest.fixture(autouse=True)
+def ns(k8s_cluster, run_id) -> str:
+    name = f"kr8s-pytest-{run_id}-{uuid.uuid4().hex[:4]}"
+    k8s_cluster.kubectl("create", "namespace", name)
+    yield name
+    k8s_cluster.kubectl("delete", "namespace", name, "--wait=false")
 
 
 @pytest.fixture

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -102,13 +102,13 @@ async def test_get_pods_as_table():
     assert len(pods.rows) > 0
 
 
-async def test_watch_pods(example_pod_spec):
+async def test_watch_pods(example_pod_spec, ns):
     kubernetes = await kr8s.asyncio.api()
     pod = await Pod(example_pod_spec)
     await pod.create()
     while not await pod.ready():
         await asyncio.sleep(0.1)
-    async for event, obj in kubernetes.watch("pods"):
+    async for event, obj in kubernetes.watch("pods", namespace=ns):
         assert event in ["ADDED", "MODIFIED", "DELETED"]
         assert isinstance(obj, Pod)
         if obj.name == pod.name:
@@ -153,7 +153,7 @@ async def test_api_resources():
 
 
 async def test_ns(ns):
-    api = await kr8s.asyncio.api()
+    api = await kr8s.asyncio.api(namespace=ns)
     assert ns == api.namespace
 
     api.namespace = "foo"


### PR DESCRIPTION
Uses a fixture to create a new namespace for each test and clean it up at the end. Clean up is done without waiting so this doesn't slow down the test suite. Should stop tests from conflicting with each other. Also should clean up resources left over from failed tests.