### PR TITLE
httpx refactor

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -67,9 +67,6 @@ class Api(object):
         if self.auth.server_ca_file:
             self._sslcontext.load_verify_locations(cafile=self.auth.server_ca_file)
 
-    async def _create_aiohttp_session(self) -> None:
-        pass
-
     async def _create_session(self) -> None:
         headers = {"User-Agent": self.__version__, "content-type": "application/json"}
         self.load_ssl_context()

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -376,14 +376,16 @@ class Api(object):
     async def api_resources(self) -> dict:
         """Get the Kubernetes API resources."""
         resources = []
-        async with self.call_api(method="GET", version="", base="/api") as response:
-            core_api_list = await response.json()
+        async with self.call_api_httpx(
+            method="GET", version="", base="/api"
+        ) as response:
+            core_api_list = response.json()
 
         for version in core_api_list["versions"]:
-            async with self.call_api(
+            async with self.call_api_httpx(
                 method="GET", version="", base="/api", url=version
             ) as response:
-                resource = await response.json()
+                resource = response.json()
             resources.extend(
                 [
                     {"version": version, **r}
@@ -391,14 +393,16 @@ class Api(object):
                     if "/" not in r["name"]
                 ]
             )
-        async with self.call_api(method="GET", version="", base="/apis") as response:
-            api_list = await response.json()
+        async with self.call_api_httpx(
+            method="GET", version="", base="/apis"
+        ) as response:
+            api_list = response.json()
         for api in sorted(api_list["groups"], key=lambda d: d["name"]):
             version = api["versions"][0]["groupVersion"]
-            async with self.call_api(
+            async with self.call_api_httpx(
                 method="GET", version="", base="/apis", url=version
             ) as response:
-                resource = await response.json()
+                resource = response.json()
             resources.extend(
                 [
                     {"version": version, **r}

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -190,7 +190,7 @@ class APIObject:
 
     async def _exists(self, ensure=False) -> bool:
         """Check if this object exists in Kubernetes."""
-        async with self.api.call_api_httpx(
+        async with self.api.call_api(
             "GET",
             version=self.version,
             url=f"{self.endpoint}/{self.name}",
@@ -206,7 +206,7 @@ class APIObject:
 
     async def create(self) -> None:
         """Create this object in Kubernetes."""
-        async with self.api.call_api_httpx(
+        async with self.api.call_api(
             "POST",
             version=self.version,
             url=self.endpoint,
@@ -221,7 +221,7 @@ class APIObject:
         if propagation_policy:
             data["propagationPolicy"] = propagation_policy
         try:
-            async with self.api.call_api_httpx(
+            async with self.api.call_api(
                 "DELETE",
                 version=self.version,
                 url=f"{self.endpoint}/{self.name}",
@@ -241,7 +241,7 @@ class APIObject:
     async def _refresh(self) -> None:
         """Refresh this object from Kubernetes."""
         try:
-            async with self.api.call_api_httpx(
+            async with self.api.call_api(
                 "GET",
                 version=self.version,
                 url=f"{self.endpoint}/{self.name}",
@@ -262,7 +262,7 @@ class APIObject:
         url = f"{self.endpoint}/{self.name}"
         if subresource:
             url = f"{url}/{subresource}"
-        async with self.api.call_api_httpx(
+        async with self.api.call_api(
             "PATCH",
             version=self.version,
             url=url,
@@ -552,7 +552,7 @@ class Pod(APIObject):
         if limit_bytes is not None:
             params["limitBytes"] = int(limit_bytes)
 
-        async with self.api.call_api_httpx(
+        async with self.api.call_api(
             "GET",
             version=self.version,
             url=f"{self.endpoint}/{self.name}/log",
@@ -683,7 +683,7 @@ class Service(APIObject):
     ) -> httpx.Response:
         if port is None:
             port = self.raw["spec"]["ports"][0]["port"]
-        async with self.api.call_api_httpx(
+        async with self.api.call_api(
             method,
             version=self.version,
             url=f"{self.endpoint}/{self.name}:{port}/proxy/{path}",

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -25,6 +25,9 @@ class PortForward:
     .. note::
         The ``ready_pods`` method should return a list of Pods that are ready to accept connections.
 
+    .. warning:
+        Currently Port Forwards only work when using ``asyncio`` and not ``trio``.
+
     Args:
         ``resource`` (Pod or Resource): The Pod or Resource to forward to.
 
@@ -130,11 +133,10 @@ class PortForward:
         while self.running:
             self.connection_attempts += 1
             try:
-                async with self.pod.api.call_api(
+                async with self.pod.api.open_websocket(
                     version=self.pod.version,
                     url=f"{self.pod.endpoint}/{self.pod.name}/portforward",
                     namespace=self.pod.namespace,
-                    websocket=True,
                     params={
                         "name": self.pod.name,
                         "namespace": self.pod.namespace,

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -82,7 +82,7 @@ async def test_concurrent_api_creation():
 async def test_bad_api_version():
     kubernetes = await kr8s.asyncio.api()
     with pytest.raises(ValueError):
-        async with kubernetes.call_api("GET", version="foo"):
+        async with kubernetes.call_api_httpx("GET", version="foo"):
             pass  # pragma: no cover
 
 

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -82,7 +82,7 @@ async def test_concurrent_api_creation():
 async def test_bad_api_version():
     kubernetes = await kr8s.asyncio.api()
     with pytest.raises(ValueError):
-        async with kubernetes.call_api_httpx("GET", version="foo"):
+        async with kubernetes.call_api("GET", version="foo"):
             pass  # pragma: no cover
 
 

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-import aiohttp
+import httpx
 import pytest
 import yaml
 
@@ -72,7 +72,7 @@ async def test_bad_auth(serviceaccount):
         serviceaccount=serviceaccount, kubeconfig="/no/file/here"
     )
     serviceaccount = Path(serviceaccount)
-    with pytest.raises(aiohttp.ClientResponseError):
+    with pytest.raises(httpx.HTTPStatusError):
         await kubernetes.version()
 
 

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -17,7 +17,6 @@ def test_trio_runs():
     trio.run(main)
 
 
-@pytest.mark.xfail(reason="trio support is not yet implemented")
 def test_trio_pod_wait_ready(example_pod_spec):
     async def main():
         pod = await kr8s.asyncio.objects.Pod(example_pod_spec)

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -8,12 +8,31 @@ import kr8s
 from kr8s._io import NamedTemporaryFile
 
 
-@pytest.mark.xfail(reason="trio support is not yet implemented")
 def test_trio_runs():
     async def main():
         kubernetes = await kr8s.asyncio.api()
         version = await kubernetes.version()
         assert "major" in version
+
+    trio.run(main)
+
+
+@pytest.mark.xfail(reason="trio support is not yet implemented")
+def test_trio_pod_wait_ready(example_pod_spec):
+    async def main():
+        pod = await kr8s.asyncio.objects.Pod(example_pod_spec)
+        await pod.create()
+        await pod.wait("condition=Ready")
+        with pytest.raises(TimeoutError):
+            await pod.wait("jsonpath='{.status.phase}'=Foo", timeout=0.1)
+        await pod.wait("condition=Ready=true")
+        await pod.wait("condition=Ready=True")
+        await pod.wait("jsonpath='{.status.phase}'=Running")
+        with pytest.raises(ValueError):
+            await pod.wait("foo=NotARealCondition")
+        await pod.delete()
+        await pod.wait("condition=Ready=False")
+        await pod.wait("delete")
 
     trio.run(main)
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -4,7 +4,6 @@ import asyncio
 import pathlib
 import time
 
-import aiohttp
 import httpx
 import pytest
 
@@ -132,6 +131,13 @@ def test_pod_wait_ready_sync(example_pod_spec):
     pod.delete()
     pod.wait("condition=Ready=False")
     pod.wait("delete")
+
+
+def test_pod_refresh_sync(example_pod_spec):
+    pod = SyncPod(example_pod_spec)
+    pod.create()
+    pod.refresh()
+    pod.delete()
 
 
 def test_pod_create_and_delete_sync(example_pod_spec):
@@ -417,7 +423,7 @@ async def test_service_proxy():
     [service] = await kubernetes.get("services", "kubernetes")
     assert service.name == "kubernetes"
     data = await service.proxy_http_get("/version", raise_for_status=False)
-    assert isinstance(data, aiohttp.ClientResponse)
+    assert isinstance(data, httpx.Response)
 
 
 async def test_pod_logs(example_pod_spec):

--- a/poetry.lock
+++ b/poetry.lock
@@ -203,21 +203,6 @@ files = [
 ]
 
 [[package]]
-name = "asyncio-atexit"
-version = "1.0.1"
-description = "Like atexit, but for asyncio"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "asyncio-atexit-1.0.1.tar.gz", hash = "sha256:1d0c71544b8ee2c484d322844ee72c0875dde6f250c0ed5b6993592ab9f7d436"},
-    {file = "asyncio_atexit-1.0.1-py3-none-any.whl", hash = "sha256:d93d5f7d5633a534abd521ce2896ed0fbe8de170bb1e65ec871d1c20eac9d376"},
-]
-
-[package.extras]
-test = ["pytest", "uvloop"]
-
-[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -1969,4 +1954,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0c59a596a4e01aa9776f2cb9bce2dcdcb1d4b02df260104c074d73ac72fdd675"
+content-hash = "404fc5a06b9e3e3b9edc44da3516ecd89dcee886eea9972bd614e901da2bcd2b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -274,7 +274,7 @@ lxml = ["lxml"]
 name = "certifi"
 version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -651,6 +651,64 @@ beautifulsoup4 = "*"
 pygments = ">=2.7"
 sphinx = ">=5.0,<7.0"
 sphinx-basic-ng = "*"
+
+[[package]]
+name = "h11"
+version = "0.14.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "httpcore"
+version = "0.17.2"
+description = "A minimal low-level HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpcore-0.17.2-py3-none-any.whl", hash = "sha256:5581b9c12379c4288fe70f43c710d16060c10080617001e6b22a3b6dbcbefd36"},
+    {file = "httpcore-0.17.2.tar.gz", hash = "sha256:125f8375ab60036db632f34f4b627a9ad085048eef7cb7d2616fea0f739f98af"},
+]
+
+[package.dependencies]
+anyio = ">=3.0,<5.0"
+certifi = "*"
+h11 = ">=0.13,<0.15"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.24.1"
+description = "The next generation HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
+]
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "idna"
@@ -1911,4 +1969,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "7daf27f418016c1633d3255ea6bbd0ce34899fe02df3ee9751bf12c5a1a08a80"
+content-hash = "0c59a596a4e01aa9776f2cb9bce2dcdcb1d4b02df260104c074d73ac72fdd675"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ files = ["kr8s/__init__.py"]
 python = "^3.8"
 aiohttp = "^3.8.4"
 pyyaml = "^6.0"
-asyncio-atexit = "^1.0.1"
 python-jsonpath = "^0.7.1"
 anyio = "^3.7.0"
 httpx = "^0.24.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pyyaml = "^6.0"
 asyncio-atexit = "^1.0.1"
 python-jsonpath = "^0.7.1"
 anyio = "^3.7.0"
+httpx = "^0.24.1"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
This is a second attempt at closing #102 and supersedes #90.

The core `kr8s._api.Api.call_api()` method now uses `httpx` under the hood and returns an `httpx.Response` object. Code throughout has been updated to use this new return value.

The only thing that hasn't been migrated is port forwarding which still relies on `aiohttp` for it's websocket implementation. We could migrate this to use `httpx-ws` in the future, but I'll open an issue to track this. For now I've factored the websocket code into a new method called `kr8s._api.Api.open_websocket()`.

This PR also removes the xfail from the `trio` test and adds another test to show that basic API and object operations work with `trio`.

Closes #102 