### PR TITLE
Expose API client methods as functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A simple, extensible Python client library for Kubernetes that feels familiar fo
 - API inspired by `kubectl` to reduce developer learning curve.
 - [Sensible defaults](https://docs.kr8s.org/en/latest/authentication.html) to reduce boiler plate.
 - No swagger generated code, human readable code only.
-- Supports both [async/await](https://docs.kr8s.org/en/latest/asyncio.html) and sync APIs.
+- Also has an [asynchronous API](https://docs.kr8s.org/en/latest/asyncio.html) that can be used with `asyncio` and `trio`.
 - [Client caching](https://docs.kr8s.org/en/latest/client.html#client-caching) to reduce passing API objects around.
 - Batteries included by providing useful utilities and methods inspired by `kubectl`.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ $ pip install kr8s
 ```python
 import kr8s
 
-api = kr8s.api()
-pods = api.get("pods")
+pods = kr8s.get("pods")
 ```
 
 See the [Client API docs](https://docs.kr8s.org/en/latest/client.html) for more examples.

--- a/docs/asyncio.md
+++ b/docs/asyncio.md
@@ -1,21 +1,19 @@
 # Asyncio
 
-`kr8s` uses `asyncio` under the hood when interacting with the Kubernetes API. However, it exposes a standard synchronous API by default.
+`kr8s` is built using async/await under the hood when interacting with the Kubernetes API. However, it exposes a standard synchronous API by default.
 
 ```python
 import kr8s
 
-api = kr8s.api()
-pods = api.get("pods")
+pods = kr8s.get("pods")
 ```
 
-For users that want it the `asyncio` API is also available via `kr8s.asyncio`.
+For users that want to use it with `asyncio` or `trio` you can find the async API is also available via `kr8s.asyncio`.
 
 ```python
 import kr8s.asyncio
 
-api = await kr8s.asyncio.api()
-pods = await api.get("pods")
+pods = await kr8s.asyncio.get("pods")
 ```
 
 Submodules including `kr8s.objects` and `kr8s.portforward` also have `asyncio` equivalents at `kr8s.asyncio.objects` and `kr8s.asyncio.portforward`.

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,27 +1,34 @@
 # Client API
 
-The [kr8s API client](#kr8s.api) can be used to interact directly with the Kubernetes API.
+To interact with the Kubernetes API `kr8s` uses an [API client](#kr8s.api). When calling functions that communicate with Kubernetes a client will be created for you, unless you want to handle it explicitly yourself.
+
+```python
+import kr8s
+
+version = kr8s.version()
+print(version)  # Prints out the version information from the Kubernetes cluster
+```
+
+To do this explicitly you would construct an API client object first.
 
 ```python
 import kr8s
 
 api = kr8s.api()
-
 version = api.version()
-print(version)
+print(version)  # Prints out the version information from the Kubernetes cluster
 ```
 
 ```{tip}
 Calling [](#kr8s.api) returns a cached instance of [](#kr8s.Api). In most use cases [](#kr8s.api) should be thought of as a singleton due to [client caching](#client-caching).
 ```
 
-The client API is inspired by `kubectl` rather than the Kubernetes API directly as it's more likely that developers will be familiar with `kubectl`.
+The `kr8s` API is inspired by `kubectl` rather than the Kubernetes API directly as it's more likely that developers will be familiar with `kubectl`.
 
 ```python
 import kr8s
 
-api = kr8s.api()
-pods = api.get("pods", namespace=kr8s.ALL)
+pods = kr8s.get("pods", namespace=kr8s.ALL)
 
 for pod in pods:
     print(pod.name)
@@ -34,7 +41,7 @@ For situations where there may not be an appropriate method to call or you want 
 To make API requests for resources more convenience `call_api` allows building the url via various kwargs.
 
 ```{note}
-Note that `call_api` is only available via the [asyncio API](asyncio).
+Note that `call_api` is only available via the [asynchronous API](asyncio).
 ```
 
 For example to get all pods you could make the following low-level call.
@@ -65,7 +72,7 @@ print(version)
 
 It is always recommended to create client objects via the [](#kr8s.api) factory function. In most use cases where you are interacting with a single Kubernetes cluster you can think of this as a singleton.
 
-However, the factory function dues support creating multiple clients and will only cache client objects that are created with the same arguments.
+However, the factory function does support creating multiple clients and will only cache client objects that are created with the same arguments.
 
 ```python
 import kr8s
@@ -78,7 +85,7 @@ api3 = kr8s.api(kubeconfig="/fizz/buzz")
 # api3 is a new kr8s.Api instance as it was created with different arguments
 ```
 
-Calling [](#kr8s.api) with no arguments will also return the first client from the cache if one exists. This is useful as you may want to explicitly create a client with custom auth at the start of your code and treat it like a singleton. The [Object API](object) makes use of this when instantiating objects with `api=None`.
+Calling [](#kr8s.api) with no arguments will also return the first client from the cache if one exists. This is useful as you may want to explicitly create a client with custom auth at the start of your code and treat it like a singleton. The `kr8s` API makes use of this whenever instantiating objects with `api=None`.
 
 ```python
 import kr8s

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ A simple, extensible Python client library for Kubernetes that feels familiar fo
 - API inspired by `kubectl` to reduce developer learning curve.
 - [Sensible defaults](https://docs.kr8s.org/en/latest/authentication.html) to reduce boiler plate.
 - No swagger generated code, human readable code only.
-- Supports both [async/await](https://docs.kr8s.org/en/latest/asyncio.html) and sync APIs.
+- Also has an [asynchronous API](https://docs.kr8s.org/en/latest/asyncio.html) that can be used with `asyncio` and `trio`.
 - [Client caching](https://docs.kr8s.org/en/latest/client.html#client-caching) to reduce passing API objects around.
 - Batteries included by providing useful utilities and methods inspired by `kubectl`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,8 +29,7 @@ $ pip install kr8s
 ```python
 import kr8s
 
-api = kr8s.api()
-pods = api.get("pods")
+pods = kr8s.get("pods")
 ```
 
 See the [Client API docs](https://docs.kr8s.org/en/latest/client.html) for more examples.

--- a/docs/object.md
+++ b/docs/object.md
@@ -5,14 +5,13 @@ Responses from the Client API are usually objects from [](#kr8s.objects) which r
 ```python
 import kr8s
 
-api = kr8s.api()
-pods = api.get("pods", namespace=kr8s.ALL)
+pods = kr8s.get("pods", namespace=kr8s.ALL)
 pod = pods[0]
 print(type(pod))
 # <class 'kr8s.objects.Pod'>
 ```
 
-In the above example the kr8s API returns a list of [](#kr8s.objects.Pod) objects.
+In the above example the `kr8s.get` function returns a list of [](#kr8s.objects.Pod) objects.
 
 ## Attributes
 
@@ -76,9 +75,9 @@ pod.ready()
 
 ## Client references
 
-All objects returned from client methods will have a reference to the client that created it at `Object.api`.
+All objects returned by `kr8s` will have a reference to the API client that created it at `Object.api`.
 
-You can also create objects yourself from a spec or get existing ones by name. You don't necessarily need to create an API client first to do this.
+You can also create objects yourself from a spec or get existing ones by name. Methods on objects that require communicating with Kubernetes will create an API client or retrieve one from the cache automatically.
 
 ```python
 # Create a new Pod
@@ -172,9 +171,9 @@ class CustomScalableObject(APIObject):
 
 Some objects such as `Pod`, `Node`, `Service` and `Deployment` have additional custom methods such as `Pod.logs()` and `Deployment.ready()` which have been implemented for convenience. It might make sense for you to implement your own utilities on your custom classes.
 
-### Using custom objects with the client API
+### Using custom objects with other `kr8s` functions
 
-When making API calls with the [client API](client) some methods such as `api.get("pods")` will want to return kr8s objects, in this case a `Pod`. The client handles this by looking up all of the subclasses of [`APIObject`](#kr8s.objects.APIObject) and matching the `kind` against the kind returned by the API. If the API returns a kind of object that there is no kr8s object to deserialize into it will raise an exception.
+When using the [`kr8s` API](client) some methods such as `kr8s.get("pods")` will want to return kr8s objects, in this case a `Pod`. The API client handles this by looking up all of the subclasses of [`APIObject`](#kr8s.objects.APIObject) and matching the `kind` against the kind returned by the API. If the API returns a kind of object that there is no kr8s object to deserialize into it will raise an exception.
 
 When you create your own custom objects that subclass [`APIObject`](#kr8s.objects.APIObject) the client is then able to use those objects in its response.
 
@@ -190,9 +189,7 @@ class CustomObject(APIObject):
     kind = "CustomObject"
     namespaced = True
 
-api = kr8s.api()
-
-cos = api.get("customobjects")  # Will return a list of CustomObject instances
+cos = kr8s.get("customobjects")  # Will return a list of CustomObject instances
 ```
 
 ```{note}

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -1,13 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
-from functools import partial
+from functools import partial, update_wrapper
 
 from ._api import ALL  # noqa
 from ._api import Api as _AsyncApi
 from ._exceptions import NotFoundError  # noqa
 from ._io import run_sync as _run_sync
 from ._io import sync as _sync  # noqa
-from .asyncio import api as _api  # noqa
+from .asyncio import (
+    api as _api,
+)
+from .asyncio import (
+    api_resources as _api_resources,
+)
+from .asyncio import (
+    get as _get,
+)
+from .asyncio import (
+    version as _version,
+)
+from .asyncio import (
+    watch as _watch,
+)
 
 __version__ = "0.0.0"
 
@@ -18,3 +32,11 @@ class Api(_AsyncApi):
 
 
 api = _run_sync(partial(_api, _asyncio=False))
+get = _run_sync(partial(_get, _asyncio=False))
+update_wrapper(get, _get)
+version = _run_sync(partial(_version, _asyncio=False))
+update_wrapper(version, _version)
+watch = _run_sync(partial(_watch, _asyncio=False))
+update_wrapper(watch, _watch)
+api_resources = _run_sync(partial(_api_resources, _asyncio=False))
+update_wrapper(api_resources, _api_resources)

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
+from __future__ import annotations
+
 import contextlib
 import json
 import ssl
@@ -193,7 +195,17 @@ class Api(object):
             break
 
     async def version(self) -> dict:
-        """Get the Kubernetes version"""
+        """Get the Kubernetes version information from the API.
+
+        Returns
+        -------
+        dict
+            The Kubernetes version information.
+
+        """
+        return await self._version()
+
+    async def _version(self) -> dict:
         async with self.call_api(method="GET", version="", base="/version") as response:
             return response.json()
 
@@ -254,7 +266,31 @@ class Api(object):
         as_object: object = None,
         **kwargs,
     ) -> List[object]:
-        """Get a Kubernetes resource."""
+        """
+        Get Kubernetes resources.
+
+        Parameters
+        ----------
+        kind : str
+            The kind of resource to get.
+        *names : List[str], optional
+            The names of specific resources to get.
+        namespace : str, optional
+            The namespace to get the resource from.
+        label_selector : Union[str, Dict], optional
+            The label selector to filter the resources by.
+        field_selector : Union[str, Dict], optional
+            The field selector to filter the resources by.
+        as_object : object, optional
+            The object to return the resources as.
+        **kwargs
+            Additional keyword arguments to pass to the API call.
+
+        Returns
+        -------
+        List[object]
+            The resources.
+        """
         return await self._get(
             kind,
             *names,
@@ -345,6 +381,10 @@ class Api(object):
                 yield event["type"], obj_cls(event["object"], api=self)
 
     async def api_resources(self) -> dict:
+        """Get the Kubernetes API resources."""
+        return await self._api_resources()
+
+    async def _api_resources(self) -> dict:
         """Get the Kubernetes API resources."""
         resources = []
         async with self.call_api(method="GET", version="", base="/api") as response:

--- a/kr8s/_io.py
+++ b/kr8s/_io.py
@@ -39,11 +39,13 @@ def run_sync(coro: Callable[..., Awaitable[T]]) -> Callable[..., T]:
 
     @wraps(coro)
     def wrapped(*args, **kwargs):
+        wrapped = partial(coro, *args, **kwargs)
+        wrapped.__doc__ = coro.__doc__
         with anyio.from_thread.start_blocking_portal() as portal:
             if inspect.iscoroutinefunction(coro):
-                return portal.call(partial(coro, *args, **kwargs))
+                return portal.call(wrapped)
             if inspect.isasyncgenfunction(coro):
-                return iter_over_async(partial(coro, *args, **kwargs))
+                return iter_over_async(wrapped)
             raise TypeError(
                 f"Expected coroutine function, got {coro.__class__.__name__}"
             )

--- a/kr8s/asyncio/__init__.py
+++ b/kr8s/asyncio/__init__.py
@@ -1,1 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
+from kr8s._api import Api  # noqa
+
 from ._api import api  # noqa
+from ._helpers import api_resources, get, version, watch  # noqa

--- a/kr8s/asyncio/_api.py
+++ b/kr8s/asyncio/_api.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._api import Api as _AsyncApi
 
 

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
-
 from typing import Dict, List, Union
 
 from kr8s._api import Api
@@ -49,13 +48,14 @@ async def watch(
 ):
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api._watch(
+    async for (t, o) in api._watch(
         kind=kind,
         namespace=namespace,
         label_selector=label_selector,
         field_selector=field_selector,
         since=since,
-    )
+    ):
+        yield (t, o)
 
 
 async def api_resources(api=None, _asyncio=True):

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
+
+from typing import Dict, List, Union
+
+from kr8s._api import Api
+
+from ._api import api as _api
+
+
+async def get(
+    kind: str,
+    *names: List[str],
+    namespace: str = None,
+    label_selector: Union[str, Dict] = None,
+    field_selector: Union[str, Dict] = None,
+    as_object: object = None,
+    api=None,
+    _asyncio=True,
+    **kwargs,
+):
+    if api is None:
+        api = await _api(_asyncio=_asyncio)
+    return await api._get(
+        kind,
+        *names,
+        namespace=namespace,
+        label_selector=label_selector,
+        field_selector=field_selector,
+        as_object=as_object,
+        **kwargs,
+    )
+
+
+async def version(api=None, _asyncio=True):
+    if api is None:
+        api = await _api(_asyncio=_asyncio)
+    return await api._version()
+
+
+async def watch(
+    kind: str,
+    namespace: str = None,
+    label_selector: Union[str, Dict] = None,
+    field_selector: Union[str, Dict] = None,
+    since: str = None,
+    api=None,
+    _asyncio=True,
+):
+    if api is None:
+        api = await _api(_asyncio=_asyncio)
+    return await api._watch(
+        kind=kind,
+        namespace=namespace,
+        label_selector=label_selector,
+        field_selector=field_selector,
+        since=since,
+    )
+
+
+async def api_resources(api=None, _asyncio=True):
+    if api is None:
+        api = await _api(_asyncio=_asyncio)
+    return await api._api_resources()
+
+
+get.__doc__ = Api.get.__doc__
+version.__doc__ = Api.version.__doc__
+watch.__doc__ = Api.watch.__doc__
+api_resources.__doc__ = Api.api_resources.__doc__

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._objects import (  # noqa
     APIObject,
     Binding,

--- a/kr8s/asyncio/portforward.py
+++ b/kr8s/asyncio/portforward.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._portforward import PortForward  # noqa

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -158,3 +158,30 @@ async def test_ns(ns):
 
     api.namespace = "foo"
     assert api.namespace == "foo"
+
+
+async def test_docstrings():
+    assert (
+        kr8s.Api.get.__doc__
+        == kr8s.asyncio.Api.get.__doc__
+        == kr8s.get.__doc__
+        == kr8s.asyncio.get.__doc__
+    )
+    assert (
+        kr8s.Api.version.__doc__
+        == kr8s.asyncio.Api.version.__doc__
+        == kr8s.version.__doc__
+        == kr8s.asyncio.version.__doc__
+    )
+    assert (
+        kr8s.Api.watch.__doc__
+        == kr8s.asyncio.Api.watch.__doc__
+        == kr8s.watch.__doc__
+        == kr8s.asyncio.watch.__doc__
+    )
+    assert (
+        kr8s.Api.api_resources.__doc__
+        == kr8s.asyncio.Api.api_resources.__doc__
+        == kr8s.api_resources.__doc__
+        == kr8s.asyncio.api_resources.__doc__
+    )

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -69,6 +69,11 @@ async def test_version():
     assert "major" in version
 
 
+def test_helper_version():
+    version = kr8s.version()
+    assert "major" in version
+
+
 async def test_concurrent_api_creation():
     async def get_api():
         api = await kr8s.asyncio.api()
@@ -88,8 +93,7 @@ async def test_bad_api_version():
 
 @pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system"])
 async def test_get_pods(namespace):
-    kubernetes = await kr8s.asyncio.api()
-    pods = await kubernetes.get("pods", namespace=namespace)
+    pods = await kr8s.asyncio.get("pods", namespace=namespace)
     assert isinstance(pods, list)
     assert len(pods) > 0
     assert isinstance(pods[0], Pod)
@@ -103,12 +107,11 @@ async def test_get_pods_as_table():
 
 
 async def test_watch_pods(example_pod_spec, ns):
-    kubernetes = await kr8s.asyncio.api()
     pod = await Pod(example_pod_spec)
     await pod.create()
     while not await pod.ready():
         await asyncio.sleep(0.1)
-    async for event, obj in kubernetes.watch("pods", namespace=ns):
+    async for event, obj in kr8s.asyncio.watch("pods", namespace=ns):
         assert event in ["ADDED", "MODIFIED", "DELETED"]
         assert isinstance(obj, Pod)
         if obj.name == pod.name:
@@ -129,8 +132,7 @@ async def test_get_deployments():
 
 
 async def test_api_resources():
-    kubernetes = await kr8s.asyncio.api()
-    resources = await kubernetes.api_resources()
+    resources = await kr8s.asyncio.api_resources()
 
     names = [r["name"] for r in resources]
     assert "nodes" in names


### PR DESCRIPTION
Closes #105 

This PR makes `get`, `watch`, `version` and `api_resources` available without constructing an API client.

```python
import kr8s

pods = kr8s.get("pods")

# is equivalent to

client = kr8s.api()
pods = client.get("pods")
```

This also works for `asyncio`.

```python
import asyncio
import kr8s.asyncio

def main():
    pods = await kr8s.asyncio.get("pods")

    # is equivalent to

    client = await kr8s.asyncio.api()
    pods = await client.get("pods")

if __name__ == "__main__":
    asyncio.run(main())
```