### PR TITLE
Handle Python 3.9 error message when running multiple loops

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -153,6 +153,7 @@ class Api(object):
                     [
                         "Event loop is closed" in str(e),
                         "bound to a different event loop" in str(e),
+                        "attached to a different loop" in str(e),
                     ]
                 ):
                     await self._create_session()


### PR DESCRIPTION
Follow up to #113 that handles Python 3.9