### PR TITLE
Use python-box for dot-notation access to object properties

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -13,6 +13,7 @@ import anyio
 import httpx
 import jsonpath
 import yaml
+from box import Box
 
 import kr8s
 import kr8s.asyncio
@@ -99,23 +100,23 @@ class APIObject:
     @property
     def metadata(self) -> dict:
         """Metadata of the Kubernetes resource."""
-        return self.raw["metadata"]
+        return Box(self.raw["metadata"])
 
     @property
     def spec(self) -> dict:
         """Spec of the Kubernetes resource."""
-        return self.raw["spec"]
+        return Box(self.raw["spec"])
 
     @property
     def status(self) -> dict:
         """Status of the Kubernetes resource."""
-        return self.raw["status"]
+        return Box(self.raw["status"])
 
     @property
     def labels(self) -> dict:
         """Labels of the Kubernetes resource."""
         try:
-            return self.raw["metadata"]["labels"]
+            return Box(self.raw["metadata"]["labels"])
         except KeyError:
             return {}
 
@@ -123,7 +124,7 @@ class APIObject:
     def annotations(self) -> dict:
         """Annotations of the Kubernetes resource."""
         try:
-            return self.raw["metadata"]["annotations"]
+            return Box(self.raw["metadata"]["annotations"])
         except KeyError:
             return {}
 
@@ -255,7 +256,7 @@ class APIObject:
 
     async def patch(self, patch, *, subresource=None) -> None:
         """Patch this object in Kubernetes."""
-        return await self._patch(patch, subresource=subresource)
+        await self._patch(patch, subresource=subresource)
 
     async def _patch(self, patch: Dict, *, subresource=None) -> None:
         """Patch this object in Kubernetes."""

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -98,35 +98,35 @@ class APIObject:
         return None
 
     @property
-    def metadata(self) -> dict:
+    def metadata(self) -> Box:
         """Metadata of the Kubernetes resource."""
         return Box(self.raw["metadata"])
 
     @property
-    def spec(self) -> dict:
+    def spec(self) -> Box:
         """Spec of the Kubernetes resource."""
         return Box(self.raw["spec"])
 
     @property
-    def status(self) -> dict:
+    def status(self) -> Box:
         """Status of the Kubernetes resource."""
         return Box(self.raw["status"])
 
     @property
-    def labels(self) -> dict:
+    def labels(self) -> Box:
         """Labels of the Kubernetes resource."""
         try:
             return Box(self.raw["metadata"]["labels"])
         except KeyError:
-            return {}
+            return Box({})
 
     @property
-    def annotations(self) -> dict:
+    def annotations(self) -> Box:
         """Annotations of the Kubernetes resource."""
         try:
             return Box(self.raw["metadata"]["annotations"])
         except KeyError:
-            return {}
+            return Box({})
 
     @property
     def replicas(self) -> int:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -535,7 +535,7 @@ async def test_object_from_file():
     assert isinstance(objects[0], Pod)
     assert objects[0].kind == "Pod"
     assert objects[0].name == "nginx"
-    assert len(objects[0].spec["containers"]) == 1
+    assert len(objects[0].spec.containers) == 1
 
 
 async def test_objects_from_file():
@@ -545,6 +545,7 @@ async def test_objects_from_file():
     assert len(objects) == 2
     assert isinstance(objects[0], Pod)
     assert isinstance(objects[1], Service)
+    assert len(objects[1].spec.ports) == 1
 
 
 async def test_objects_from_files():

--- a/poetry.lock
+++ b/poetry.lock
@@ -1262,6 +1262,41 @@ files = [
 pytest = ">=5.0.0"
 
 [[package]]
+name = "python-box"
+version = "7.0.1"
+description = "Advanced Python dictionaries with dot notation access"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-box-7.0.1.tar.gz", hash = "sha256:dc6724f88255ccbc07092abd506281439cc2b75c6569c754ffc2b22580e7ae06"},
+    {file = "python_box-7.0.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:92093bf5b1500004e3608b3f39e54230b21301ffb00ff5f4dbf775f2a409a7a9"},
+    {file = "python_box-7.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cccb85f9cbf64eda51c773f3db68aa60291ec1356b0774c37bcd4e13f26b90e7"},
+    {file = "python_box-7.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:f394cca98c777b25836faf25cb5afdc88c01dc753a5aab80055a038229091b7b"},
+    {file = "python_box-7.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:86182565c9ebe9ee4a3aece1a55d9d5451c6a44b5ec127a5e4d315909efe6d10"},
+    {file = "python_box-7.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:33d61b81133d1ddf6d85d0658c4c9aca871208c28df74e660dbdfe68f9b470ce"},
+    {file = "python_box-7.0.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:042d10f33e56a3b3432a94a23c90672a7f32f6de7116cdd9bc59d852ca08f5f7"},
+    {file = "python_box-7.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6a6d71c3c2ebed3f4c888edfa96bc5768f5e7641c4b0b6017d70f68a325811cf"},
+    {file = "python_box-7.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:dc135cf06ef3dde501de9baab21d908088fb03e2de09e3fe80e8a4f1dcd1ab2b"},
+    {file = "python_box-7.0.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:443ff7320c1b7e64384189f532c386600a6c31db9ddd9ded8ecc3ad4c43d0edb"},
+    {file = "python_box-7.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6b8265e842eee33dd5d1b129b8da900ec0b6f80db70680b633f9086807f42fb9"},
+    {file = "python_box-7.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:fbb14fac0ff0b2b42e47041b7b8b4f1f8d6f6ac086c8e68b7f0358602905653e"},
+    {file = "python_box-7.0.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:84867f6527bbd1d17bc7534e1c64ccd1d173d973ae5eb202f04bdf8c0ca3a690"},
+    {file = "python_box-7.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e35521b9b96cf6a18ecfef7ebcf73fe326956a7b5d789c4ff0a01dc43edd6ce"},
+    {file = "python_box-7.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:f9254a1c7ec5e729e256f9a223773aa8a76d7a995f4d6be0015f74ab93a0f97c"},
+    {file = "python_box-7.0.1-py3-none-any.whl", hash = "sha256:f26f210b2257fd973413e75e8b91aaff9c95d7d61266426a7d3df473c4adcfd4"},
+]
+
+[package.extras]
+all = ["msgpack", "ruamel.yaml (>=0.17)", "toml"]
+msgpack = ["msgpack"]
+pyyaml = ["PyYAML"]
+ruamel-yaml = ["ruamel.yaml (>=0.17)"]
+toml = ["toml"]
+tomli = ["tomli", "tomli-w"]
+yaml = ["ruamel.yaml (>=0.17)"]
+
+[[package]]
 name = "python-jsonpath"
 version = "0.7.1"
 description = "Another JSONPath implementation for Python."
@@ -1954,4 +1989,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "404fc5a06b9e3e3b9edc44da3516ecd89dcee886eea9972bd614e901da2bcd2b"
+content-hash = "2e20fef5ee3e43f02762bd26debbb1eea4783853bfa12771e731c09e3f8e82f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ pyyaml = "^6.0"
 python-jsonpath = "^0.7.1"
 anyio = "^3.7.0"
 httpx = "^0.24.1"
+python-box = "^7.0.1"
 
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
Many other Python client libraries for Kubernetes support accessing all attributes as properties. However in `kr8s` things like `Pod.spec` return a `dict`.

```python
from kr8s.objects import Pod

pod = Pod({
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": "my-pod",
            "namespace": "default",
            "labels": {"hello": "world"},
            "annotations": {"foo": "bar"},
        },
        "spec": {
            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause"}]
        },
    })

print(type(pod.spec))  # <class 'dict'>
```

So if we wanted to get the name of the container we would need to do

```python
pod.spec["containers"][0]["name"]
```

With this PR properties like `.spec` return a [`Box` dict](https://github.com/cdgriffith/Box/wiki/Quick-Start) which allows us to do things like this in addition to regular dict functionality.

```python
pod.spec.containers[0].name
```