### PR TITLE
Enable casting between Kubernetes client libraries

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -196,3 +196,27 @@ cos = kr8s.get("customobjects")  # Will return a list of CustomObject instances
 If multiple subclasses of [`APIObject`](#kr8s.objects.APIObject) are created with the same API version and kind the first one registered will be used.
 ```
 
+## Interoperability with other libraries
+
+If you are also using other Kubernetes client libraries including `kubernetes`, `kubernetes-asyncio`, `pykube-ng` or `lightkube` you can easily convert resource objects from those libraries to `kr8s` objects.
+
+```python
+import pykube
+
+api = pykube.HTTPClient(pykube.KubeConfig.from_file())
+pykube_pod = pykube.Pod.objects(api).filter(namespace="gondor-system").get(name="my-pod")
+```
+
+Objects from other libraries can be cast directly to `kr8s` objects.
+
+```python
+import kr8s
+
+kr8s_pod = kr8s.objects.Pod(pykube_pod)
+```
+
+For some libraries including `pykube-ng` and `lightkube` we also have utility methods that support casting back again.
+
+```python
+pykube_pod = kr8s_pod.to_pykube(api)  # Pykube requires you to provide every object with an instance of HTTPClient so we pass it here
+```

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -41,8 +41,10 @@ class APIObject:
             self._raw = {"metadata": {"name": resource}}
         elif isinstance(resource, dict):
             self._raw = resource
+        elif hasattr(resource, "to_dict"):
+            self._raw = resource.to_dict()
         else:
-            raise ValueError("resource must be a dict or a string")
+            raise ValueError("resource must be a dict, string or have a to_dict method")
         if namespace is not None:
             self._raw["metadata"]["namespace"] = namespace
         self.api = api
@@ -426,6 +428,14 @@ class APIObject:
 
         """
         await child._set_owner(self)
+
+    def to_lightkube(self) -> Any:
+        """Return a lightkube representation of this object."""
+        try:
+            from lightkube import codecs
+        except ImportError:
+            raise ImportError("lightkube is not installed")
+        return codecs.from_dict(self.raw)
 
 
 ## v1 objects

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -610,3 +610,21 @@ async def test_cast_to_from_lightkube(example_pod_spec):
     assert isinstance(lightkube_pod, LightkubePod)
     assert lightkube_pod.metadata.name == example_pod_spec["metadata"]["name"]
     assert lightkube_pod.metadata.namespace == example_pod_spec["metadata"]["namespace"]
+
+
+async def test_cast_to_from_kubernetes(example_pod_spec):
+    kubernetes = pytest.importorskip("kubernetes")
+
+    starting_pod = kubernetes.client.models.v1_pod.V1Pod(
+        api_version=example_pod_spec["apiVersion"],
+        kind=example_pod_spec["kind"],
+        metadata=example_pod_spec["metadata"],
+        spec=example_pod_spec["spec"],
+    )
+
+    kr8s_pod = await Pod(starting_pod)
+    assert isinstance(kr8s_pod, Pod)
+    assert kr8s_pod.name == example_pod_spec["metadata"]["name"]
+    assert kr8s_pod.namespace == example_pod_spec["metadata"]["namespace"]
+    assert kr8s_pod.kind == "Pod"
+    assert kr8s_pod.version == "v1"

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -628,3 +628,21 @@ async def test_cast_to_from_kubernetes(example_pod_spec):
     assert kr8s_pod.namespace == example_pod_spec["metadata"]["namespace"]
     assert kr8s_pod.kind == "Pod"
     assert kr8s_pod.version == "v1"
+
+
+async def test_cast_to_from_pykube_ng(example_pod_spec):
+    pykube = pytest.importorskip("pykube")
+
+    starting_pod = pykube.objects.Pod(None, example_pod_spec)
+
+    kr8s_pod = await Pod(starting_pod)
+    assert isinstance(kr8s_pod, Pod)
+    assert kr8s_pod.name == example_pod_spec["metadata"]["name"]
+    assert kr8s_pod.namespace == example_pod_spec["metadata"]["namespace"]
+    assert kr8s_pod.kind == "Pod"
+    assert kr8s_pod.version == "v1"
+
+    pykube_pod = kr8s_pod.to_pykube(None)
+    assert isinstance(pykube_pod, pykube.objects.Pod)
+    assert pykube_pod.name == example_pod_spec["metadata"]["name"]
+    assert pykube_pod.namespace == example_pod_spec["metadata"]["namespace"]

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -590,3 +590,23 @@ async def test_adoption(nginx_service):
     await nginx_service.delete()
     while await nginx_pod.exists():
         await asyncio.sleep(0.1)
+
+
+async def test_cast_to_from_lightkube(example_pod_spec):
+    pytest.importorskip("lightkube")
+    from lightkube import codecs
+    from lightkube.resources.core_v1 import Pod as LightkubePod
+
+    starting_pod = codecs.from_dict(example_pod_spec)
+
+    kr8s_pod = await Pod(starting_pod)
+    assert isinstance(kr8s_pod, Pod)
+    assert kr8s_pod.name == example_pod_spec["metadata"]["name"]
+    assert kr8s_pod.namespace == example_pod_spec["metadata"]["namespace"]
+    assert kr8s_pod.kind == "Pod"
+    assert kr8s_pod.version == "v1"
+
+    lightkube_pod = kr8s_pod.to_lightkube()
+    assert isinstance(lightkube_pod, LightkubePod)
+    assert lightkube_pod.metadata.name == example_pod_spec["metadata"]["name"]
+    assert lightkube_pod.metadata.namespace == example_pod_spec["metadata"]["namespace"]

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -630,6 +630,24 @@ async def test_cast_to_from_kubernetes(example_pod_spec):
     assert kr8s_pod.version == "v1"
 
 
+async def test_cast_to_from_kubernetes_asyncio(example_pod_spec):
+    kubernetes_asyncio = pytest.importorskip("kubernetes_asyncio")
+
+    starting_pod = kubernetes_asyncio.client.models.v1_pod.V1Pod(
+        api_version=example_pod_spec["apiVersion"],
+        kind=example_pod_spec["kind"],
+        metadata=example_pod_spec["metadata"],
+        spec=example_pod_spec["spec"],
+    )
+
+    kr8s_pod = await Pod(starting_pod)
+    assert isinstance(kr8s_pod, Pod)
+    assert kr8s_pod.name == example_pod_spec["metadata"]["name"]
+    assert kr8s_pod.namespace == example_pod_spec["metadata"]["namespace"]
+    assert kr8s_pod.kind == "Pod"
+    assert kr8s_pod.version == "v1"
+
+
 async def test_cast_to_from_pykube_ng(example_pod_spec):
     pykube = pytest.importorskip("pykube")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -834,6 +834,27 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.0 || >=0.43.0"
 adal = ["adal (>=1.0.2)"]
 
 [[package]]
+name = "kubernetes-asyncio"
+version = "24.2.3"
+description = "Kubernetes asynchronous python client"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "kubernetes_asyncio-24.2.3-py3-none-any.whl", hash = "sha256:48f3bd583eeb16fbeb0767b0e190039013c1a4a7f4af5178ca3a6a904a7b6aba"},
+    {file = "kubernetes_asyncio-24.2.3.tar.gz", hash = "sha256:01b0f22dbb9e83a333dc0d3c7b00bf76483cf18071a70dd022fdeaae04b81e93"},
+]
+
+[package.dependencies]
+aiohttp = ">=3.7.0,<4.0.0"
+certifi = ">=14.05.14"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=3.12"
+setuptools = ">=21.0.0"
+six = ">=1.9.0"
+urllib3 = ">=1.24.2"
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.9.0"
 description = "A fast and thorough lazy object proxy."
@@ -2209,4 +2230,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "fde02f45ba95eefc6dbf7591c787c097d4f6f269688859b8f54d1797d5a9aa71"
+content-hash = "4b81a670fb5d0fa256a34929a01dd1bfdd2a498cad87270ab015c09a2176a2db"

--- a/poetry.lock
+++ b/poetry.lock
@@ -256,6 +256,18 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "cachetools"
+version = "5.3.1"
+description = "Extensible memoizing collections and decorators"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.3.1-py3-none-any.whl", hash = "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590"},
+    {file = "cachetools-5.3.1.tar.gz", hash = "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"},
+]
+
+[[package]]
 name = "certifi"
 version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -638,6 +650,31 @@ sphinx = ">=5.0,<7.0"
 sphinx-basic-ng = "*"
 
 [[package]]
+name = "google-auth"
+version = "2.17.3"
+description = "Google Authentication Library"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+files = [
+    {file = "google-auth-2.17.3.tar.gz", hash = "sha256:ce311e2bc58b130fddf316df57c9b3943c2a7b4f6ec31de9663a9333e4064efc"},
+    {file = "google_auth-2.17.3-py2.py3-none-any.whl", hash = "sha256:f586b274d3eb7bd932ea424b1c702a30e0393a2e2bc4ca3eae8263ffd8be229f"},
+]
+
+[package.dependencies]
+cachetools = ">=2.0.0,<6.0"
+pyasn1-modules = ">=0.2.1"
+rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+six = ">=1.9.0"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
+enterprise-cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
+pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0dev)"]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -768,6 +805,33 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "kubernetes"
+version = "26.1.0"
+description = "Kubernetes python client"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "kubernetes-26.1.0-py2.py3-none-any.whl", hash = "sha256:e3db6800abf7e36c38d2629b5cb6b74d10988ee0cba6fba45595a7cbe60c0042"},
+    {file = "kubernetes-26.1.0.tar.gz", hash = "sha256:5854b0c508e8d217ca205591384ab58389abdae608576f9c9afc35a3c76a366c"},
+]
+
+[package.dependencies]
+certifi = ">=14.05.14"
+google-auth = ">=1.0.1"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=5.4.1"
+requests = "*"
+requests-oauthlib = "*"
+setuptools = ">=21.0.0"
+six = ">=1.9.0"
+urllib3 = ">=1.24.2"
+websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.0 || >=0.43.0"
+
+[package.extras]
+adal = ["adal (>=1.0.2)"]
 
 [[package]]
 name = "lazy-object-proxy"
@@ -1089,6 +1153,23 @@ testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=7,<8)", "pytest-cov", 
 testing-docutils = ["pygments", "pytest (>=7,<8)", "pytest-param-files (>=0.3.4,<0.4.0)"]
 
 [[package]]
+name = "oauthlib"
+version = "3.2.2"
+description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
+    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+]
+
+[package.extras]
+rsa = ["cryptography (>=3.0.0)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
+
+[[package]]
 name = "outcome"
 version = "1.2.0"
 description = "Capture the outcome of Python function calls."
@@ -1130,6 +1211,33 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pyasn1"
+version = "0.5.0"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "pyasn1-0.5.0-py2.py3-none-any.whl", hash = "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57"},
+    {file = "pyasn1-0.5.0.tar.gz", hash = "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.3.0"
+description = "A collection of ASN.1-based protocols modules"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+files = [
+    {file = "pyasn1_modules-0.3.0-py2.py3-none-any.whl", hash = "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"},
+    {file = "pyasn1_modules-0.3.0.tar.gz", hash = "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.6.0"
 
 [[package]]
 name = "pycparser"
@@ -1326,6 +1434,21 @@ tomli = ["tomli", "tomli-w"]
 yaml = ["ruamel.yaml (>=0.17)"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-jsonpath"
 version = "0.7.1"
 description = "Another JSONPath implementation for Python."
@@ -1420,6 +1543,57 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "requests-oauthlib"
+version = "1.3.1"
+description = "OAuthlib authentication support for Requests."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},
+    {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
+]
+
+[package.dependencies]
+oauthlib = ">=3.0.0"
+requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+description = "Pure-Python RSA implementation"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "setuptools"
+version = "68.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1827,6 +2001,23 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "websocket-client"
+version = "1.6.1"
+description = "WebSocket client for Python with low level API options"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "websocket-client-1.6.1.tar.gz", hash = "sha256:c951af98631d24f8df89ab1019fc365f2227c0892f12fd150e935607c79dd0dd"},
+    {file = "websocket_client-1.6.1-py3-none-any.whl", hash = "sha256:f1f9f2ad5291f0225a49efad77abf9e700b6fef553900623060dad6e26503b9d"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
 name = "wrapt"
 version = "1.15.0"
 description = "Module for decorators, wrappers and monkey patching."
@@ -2018,4 +2209,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6cbc73bccd16add09c7ef70c649e483d3edc226d744f6b9ab47c32797fb68dbc"
+content-hash = "58a54d823af5669dc9249054c8042d09e1419f47dcc047b756174aab6b0f4be1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1268,14 +1268,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pykube-ng"
-version = "22.9.0"
+version = "23.6.0"
 description = "Python client library for Kubernetes"
 category = "dev"
 optional = false
 python-versions = ">=3.8,<4"
 files = [
-    {file = "pykube-ng-22.9.0.tar.gz", hash = "sha256:1cd761ed9c7768958fdb92a404b53a5b2b26f71314bbd1c5d1fcf4f45896e2c0"},
-    {file = "pykube_ng-22.9.0-py3-none-any.whl", hash = "sha256:6f414281d4ec64800aaa9603c0eeeff5d591072efddf8c5faaa483f7dbc828d8"},
+    {file = "pykube-ng-23.6.0.tar.gz", hash = "sha256:46de8e17ed87c1a1014667d60e7d94a1f3fa2b8037b41e67d32c28b5869af35d"},
+    {file = "pykube_ng-23.6.0-py3-none-any.whl", hash = "sha256:63f20f634bfcd83966edec32f892286f75dffb817a2c097434ecc039e558ec8f"},
 ]
 
 [package.dependencies]
@@ -2209,4 +2209,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "58a54d823af5669dc9249054c8042d09e1419f47dcc047b756174aab6b0f4be1"
+content-hash = "fde02f45ba95eefc6dbf7591c787c097d4f6f269688859b8f54d1797d5a9aa71"

--- a/poetry.lock
+++ b/poetry.lock
@@ -816,6 +816,35 @@ files = [
 ]
 
 [[package]]
+name = "lightkube"
+version = "0.13.0"
+description = "Lightweight kubernetes client library"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "lightkube-0.13.0-py3-none-any.whl", hash = "sha256:1ca46d3b9fae83858149c95af09cd92e34eed611a54c42d1034b02c73ce683d9"},
+    {file = "lightkube-0.13.0.tar.gz", hash = "sha256:9eea3f2e123c672aaba7eca90af9cec1b39b97b318e07aec3ad0fe1a14cf5a31"},
+]
+
+[package.dependencies]
+httpx = ">=0.24.0"
+lightkube-models = ">=1.15.12.0"
+PyYAML = "*"
+
+[[package]]
+name = "lightkube-models"
+version = "1.27.1.4"
+description = "Models and Resources for lightkube module"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "lightkube-models-1.27.1.4.tar.gz", hash = "sha256:5caa97ed46bde5ae8a4313ebf3fa3d0135388d0aea0752261d4720e24d982fb0"},
+    {file = "lightkube_models-1.27.1.4-py3-none-any.whl", hash = "sha256:206abb6d184a07ed84c20fbabe494847e892de2c38ed302f39a87b4ed1f7bcd9"},
+]
+
+[[package]]
 name = "livereload"
 version = "2.6.3"
 description = "Python LiveReload is an awesome tool for web developers"
@@ -1989,4 +2018,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2e20fef5ee3e43f02762bd26debbb1eea4783853bfa12771e731c09e3f8e82f7"
+content-hash = "6cbc73bccd16add09c7ef70c649e483d3edc226d744f6b9ab47c32797fb68dbc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pytest-cov = "^4.0.0"
 trio = "^0.22.0"
 lightkube = "^0.13.0"
 kubernetes = "^26.1.0"
+pykube-ng = "^23.6.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pytest-rerunfailures = "^11.1.2"
 pytest-cov = "^4.0.0"
 trio = "^0.22.0"
 lightkube = "^0.13.0"
+kubernetes = "^26.1.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ pytest-timeout = "^2.1.0"
 pytest-rerunfailures = "^11.1.2"
 pytest-cov = "^4.0.0"
 trio = "^0.22.0"
+lightkube = "^0.13.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ trio = "^0.22.0"
 lightkube = "^0.13.0"
 kubernetes = "^26.1.0"
 pykube-ng = "^23.6.0"
+kubernetes-asyncio = "^24.2.3"
 
 
 [tool.poetry.group.docs.dependencies]


### PR DESCRIPTION
If folks are also using other Kubernetes client libraries including `kubernetes`, `kubernetes-asyncio`, `pykube-ng` or `lightkube` this PR allows them to convert resource objects from those libraries to `kr8s` objects.

```python
import pykube

api = pykube.HTTPClient(pykube.KubeConfig.from_file())
pykube_pod = pykube.Pod.objects(api).filter(namespace="gondor-system").get(name="my-pod")
```

Objects from other libraries can be cast directly to `kr8s` objects.

```python
import kr8s

kr8s_pod = kr8s.objects.Pod(pykube_pod)
```

For some libraries including `pykube-ng` and `lightkube` we also have utility methods that support casting back again.

```python
pykube_pod = kr8s_pod.to_pykube(api)  # Pykube requires you to provide every object with an instance of HTTPClient so we pass it here
```