### PR TITLE
Handle missing certificate authority

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -62,6 +62,13 @@ class KubeAuth:
 
     async def ssl_context(self):
         async with self.__auth_lock:
+            if (
+                not self.client_key_file
+                and not self.client_cert_file
+                and not self.server_ca_file
+            ):
+                # If no cert information is provided, skip verification
+                return False
             sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             if self.client_key_file:
                 sslcontext.load_cert_chain(

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -146,19 +146,27 @@ async def kubectl_proxy(k8s_cluster):
     proxy.kill()
 
 
+@pytest.fixture(scope="session")
+def k8s_token(k8s_cluster):
+    # Apply the serviceaccount.yaml
+    k8s_cluster.kubectl(
+        "apply", "-f", str(HERE / "tests" / "resources" / "serviceaccount.yaml")
+    )
+    yield k8s_cluster.kubectl("create", "token", "pytest")
+    # Delete the serviceaccount.yaml
+    k8s_cluster.kubectl(
+        "delete", "-f", str(HERE / "tests" / "resources" / "serviceaccount.yaml")
+    )
+
+
 @pytest.fixture
-def serviceaccount(k8s_cluster):
+def serviceaccount(k8s_cluster, k8s_token):
     # Load kubeconfig
     kubeconfig = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
 
     # Get the server host and port from the kubeconfig
     _hostport = kubeconfig["clusters"][0]["cluster"]["server"].split("//")[1]
     host, port = _hostport.split(":")
-
-    # Apply the serviceaccount.yaml
-    k8s_cluster.kubectl(
-        "apply", "-f", str(HERE / "tests" / "resources" / "serviceaccount.yaml")
-    )
 
     # Create a temporary directory and populate it with the serviceaccount files
     with tempfile.TemporaryDirectory() as tempdir, set_env(
@@ -171,16 +179,10 @@ def serviceaccount(k8s_cluster):
                 kubeconfig["clusters"][0]["cluster"]["certificate-authority-data"]
             ).decode()
         )
-        token = k8s_cluster.kubectl("create", "token", "pytest")
         namespace = "default"
-        (tempdir / "token").write_text(token)
+        (tempdir / "token").write_text(k8s_token)
         (tempdir / "namespace").write_text(namespace)
         yield str(tempdir)
-
-    # Delete the serviceaccount.yaml
-    k8s_cluster.kubectl(
-        "delete", "-f", str(HERE / "tests" / "resources" / "serviceaccount.yaml")
-    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
In the case that no `server_ca_file` is present in the config we will skip SSL verification.

Closes #139 