### PR TITLE
Use default verification instead of no verification

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -67,8 +67,8 @@ class KubeAuth:
                 and not self.client_cert_file
                 and not self.server_ca_file
             ):
-                # If no cert information is provided, skip verification
-                return False
+                # If no cert information is provided, fall back to default verification
+                return True
             sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             if self.client_key_file:
                 sslcontext.load_cert_chain(


### PR DESCRIPTION
As noted in https://github.com/kr8s-org/kr8s/issues/139#issuecomment-1691571098 it's better to set this to `True` to fall back to default verification instead of `False` for no verification.