### PR TITLE
Allow null values when parsing exec from kubeconfig

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -116,10 +116,10 @@ class KubeAuth:
                     "Only client.authentication.k8s.io/v1beta1 is supported for exec auth"
                 )
             command = self._user["exec"]["command"]
-            args = self._user["exec"].get("args", [])
+            args = self._user["exec"].get("args") or []
             env = os.environ.copy()
             env.update(
-                **{e["name"]: e["value"] for e in self._user["exec"].get("env", [])}
+                **{e["name"]: e["value"] for e in self._user["exec"].get("env") or []}
             )
             data = json.loads(await check_output(command, *args, env=env))["status"]
             if "token" in data:


### PR DESCRIPTION
Many kubeconfig generators & tutorials (such as the [default setup for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)) cause `null` values to be added for user.exec.env and user.exec.args. The official client found it relevant to fix this exact issue here in 2018: https://github.com/kubernetes-client/python-base/pull/91

This relaxes the auth code to treat null/falsey values as empty args/env.

While a workaround is removing the null rows from one's kubeconfig, it's not necessarily given that people know how to do this (or have permissions, with certain setups!), so it can cause first-time users to see a TypeError as the first thing they see upon using the library. There should be no downsides to the fix.