### PR TITLE
Allow setting the context to use in the kr8s API client

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,6 +59,17 @@ import kr8s
 client = kr8s.api(kubeconfig="/path/to/kube/config")
 ```
 
+#### Context
+
+If you have multiple contexts in your config and you do not want to use the default or currently selected one you can set this explicitly.
+
+```python
+import kr8s
+
+client = kr8s.api(context="foo-context")
+```
+
+
 ### Service Account
 
 When running inside a Pod with a service account, credentials will be mounted into `/var/run/secrets/kubernetes.io/serviceaccount` so `kr8s` will also check there. However you can specify an alternate path if you know that service account style credentials are stored elsewhere.

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -48,6 +48,7 @@ class Api(object):
             kubeconfig=self._kubeconfig,
             serviceaccount=self._serviceaccount,
             namespace=kwargs.get("namespace"),
+            context=kwargs.get("context"),
         )
         thread_id = threading.get_ident()
         if thread_id not in Api._instances:

--- a/kr8s/asyncio/_api.py
+++ b/kr8s/asyncio/_api.py
@@ -10,6 +10,7 @@ async def api(
     kubeconfig: str = None,
     serviceaccount: str = None,
     namespace: str = None,
+    context: str = None,
     _asyncio: bool = True,
 ) -> _AsyncApi:
     """Create a :class:`kr8s.Api` object for interacting with the Kubernetes API.
@@ -46,4 +47,5 @@ async def api(
         kubeconfig=kubeconfig,
         serviceaccount=serviceaccount,
         namespace=namespace,
+        context=context,
     )


### PR DESCRIPTION
Closes #158 

If you have multiple contexts in your config and you do not want to use the default or currently selected one you can now set this explicitly.

```python
import kr8s

client = kr8s.api(context="foo-context")
```

You can also find out which context has been selected.

```python
import kr8s

client = kr8s.api()
print(client.auth.active_context)
```