### PR TITLE
Disable timeout on watch

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -387,6 +387,7 @@ class Api(object):
             field_selector=field_selector,
             params={"resourceVersion": since} if since else None,
             watch=True,
+            timeout=None,
         ) as (obj_cls, response):
             async for line in response.aiter_lines():
                 event = json.loads(line)


### PR DESCRIPTION
While using the `pod.wait` API, I noticed that timeouts occurred earlier than I specified. It seems that `httpx` applies a default timeout of 5s on calls to `stream` as well as the usual `send` API. I've added `timeout=None` to the `_api._watch` to remedy this. Let me know if this behavior is desirable. Thanks for all your work on this library!