### PR TITLE
Add support for snapshot.storage.k8s.io/v1

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1110,6 +1110,40 @@ class Role(APIObject):
     namespaced = True
 
 
+## snapshot.storage.k8s.io/v1
+
+
+class VolumeSnapshotClass(APIObject):
+    """A Kubernetes VolumeSnapshotClass."""
+
+    version = "snapshot.storage.k8s.io/v1"
+    endpoint = "volumesnapshotclasses"
+    kind = "VolumeSnapshotClass"
+    plural = "volumesnapshotclasses"
+    singular = "volumesnapshotclass"
+    namespaced = False
+
+class VolumeSnapshot(APIObject):
+    """A Kubernetes VolumeSnapshot."""
+
+    version = "snapshot.storage.k8s.io/v1"
+    endpoint = "volumesnapshots"
+    kind = "VolumeSnapshot"
+    plural = "volumesnapshots"
+    singular = "volumesnapshot"
+    namespaced = True
+
+class VolumeSnapshotContent(APIObject):
+    """A Kubernetes VolumeSnapshotContent."""
+
+    version = "snapshot.storage.k8s.io/v1"
+    endpoint = "volumesnapshotcontents"
+    kind = "VolumeSnapshotContent"
+    plural = "volumesnapshotcontents"
+    singular = "volumesnapshotcontent"
+    namespaced = False
+
+
 ## apiextensions.k8s.io/v1 objects
 
 

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1123,6 +1123,7 @@ class VolumeSnapshotClass(APIObject):
     singular = "volumesnapshotclass"
     namespaced = False
 
+
 class VolumeSnapshot(APIObject):
     """A Kubernetes VolumeSnapshot."""
 
@@ -1132,6 +1133,7 @@ class VolumeSnapshot(APIObject):
     plural = "volumesnapshots"
     singular = "volumesnapshot"
     namespaced = True
+
 
 class VolumeSnapshotContent(APIObject):
     """A Kubernetes VolumeSnapshotContent."""

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -37,6 +37,9 @@ from kr8s._objects import (  # noqa
     ServiceAccount,
     StatefulSet,
     Table,
+    VolumeSnapshot,
+    VolumeSnapshotClass,
+    VolumeSnapshotContent,
     object_from_name_type,
     objects_from_files,
 )

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -109,6 +109,15 @@ from ._objects import (
 from ._objects import (
     Table as _Table,
 )
+from ._objects import (
+    VolumeSnapshot as _VolumeSnapshot,
+)
+from ._objects import (
+    VolumeSnapshotClass as _VolumeSnapshotClass,
+)
+from ._objects import (
+    VolumeSnapshotContent as _VolumeSnapshotContent,
+)
 from ._objects import get_class, new_class, object_from_spec  # noqa
 from ._objects import object_from_name_type as _object_from_name_type
 from ._objects import objects_from_files as _objects_from_files
@@ -323,6 +332,20 @@ class CustomResourceDefinition(_CustomResourceDefinition):
     __doc__ = _CustomResourceDefinition.__doc__
     _asyncio = False
 
+@sync
+class VolumeSnapshotClass(_VolumeSnapshotClass):
+    __doc__ = _VolumeSnapshotClass.__doc__
+    _asyncio = False
+
+@sync
+class VolumeSnapshot(_VolumeSnapshot):
+    __doc__ = _VolumeSnapshot.__doc__
+    _asyncio = False
+
+@sync
+class VolumeSnapshotContent(_VolumeSnapshotContent):
+    __doc__ = _VolumeSnapshotContent.__doc__
+    _asyncio = False
 
 @sync
 class Table(_Table):

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -332,20 +332,24 @@ class CustomResourceDefinition(_CustomResourceDefinition):
     __doc__ = _CustomResourceDefinition.__doc__
     _asyncio = False
 
+
 @sync
 class VolumeSnapshotClass(_VolumeSnapshotClass):
     __doc__ = _VolumeSnapshotClass.__doc__
     _asyncio = False
+
 
 @sync
 class VolumeSnapshot(_VolumeSnapshot):
     __doc__ = _VolumeSnapshot.__doc__
     _asyncio = False
 
+
 @sync
 class VolumeSnapshotContent(_VolumeSnapshotContent):
     __doc__ = _VolumeSnapshotContent.__doc__
     _asyncio = False
+
 
 @sync
 class Table(_Table):


### PR DESCRIPTION
Adds the necessary definitions for interacting with `VolumeSnapshotClass`, `VolumeSnapshot`, `VolumeSnapshotContent`. I noticed that `StorageClass` isn't a provided type so should `VolumeSnapshotClass` be excluded? 