### PR TITLE
Handle certificate-authority in kube config

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -164,7 +164,7 @@ class KubeAuth:
                 )
                 self.server_ca_file = str(ca_file)
         if "certificate-authority" in self._cluster:
-            if os.path.isabs(self._cluster["certificate-authority"]):
+            if os.path.isfile(self._cluster["certificate-authority"]):
                 self.server_ca_file = self._cluster["certificate-authority"]
             else:
                 self.server_ca_file = os.path.join(

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -168,7 +168,7 @@ class KubeAuth:
                 self.server_ca_file = self._cluster["certificate-authority"]
             else:
                 self.server_ca_file = os.path.join(
-                    os.path.expanduser("~/.kube/"),
+                    os.path.dirname(self._kubeconfig),
                     self._cluster["certificate-authority"],
                 )
         if "token" in self._user:

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -163,6 +163,14 @@ class KubeAuth:
                     base64.b64decode(self._cluster["certificate-authority-data"])
                 )
                 self.server_ca_file = str(ca_file)
+        if "certificate-authority" in self._cluster:
+            if os.path.isabs(self._cluster["certificate-authority"]):
+                self.server_ca_file = self._cluster["certificate-authority"]
+            else:
+                self.server_ca_file = os.path.join(
+                    os.path.expanduser("~/.kube/"),
+                    self._cluster["certificate-authority"],
+                )
         if "token" in self._user:
             self.token = self._user["token"]
         if "username" in self._user:


### PR DESCRIPTION
Kube configs supports `certificate-authority-data`, which kr8s handles, and `certificate-authority`, which is just a path to a cert file, and kr8s doesn't handle. This PR adds support for that. This unblocks our ability to use dask-kubernetes locally.

Closes: https://github.com/kr8s-org/kr8s/issues/175