### PR TITLE
Raise better exception when API timeouts happen

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -6,7 +6,7 @@ import kr8s.objects  # noqa
 
 from ._api import ALL  # noqa
 from ._api import Api as _AsyncApi
-from ._exceptions import NotFoundError  # noqa
+from ._exceptions import APITimeoutError, ConnectionClosedError, NotFoundError  # noqa
 from ._io import run_sync as _run_sync
 from ._io import sync as _sync  # noqa
 from .asyncio import (

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -14,6 +14,7 @@ import httpx
 
 from ._auth import KubeAuth
 from ._data_utils import dict_to_selector
+from ._exceptions import APITimeoutError
 
 ALL = "all"
 
@@ -153,6 +154,10 @@ class Api(object):
                     continue
                 else:
                     raise
+            except httpx.ReadTimeout as e:
+                raise APITimeoutError(
+                    "Timeout while waiting for the Kubernetes API server"
+                ) from e
             except RuntimeError as e:
                 # If the client is reused on a different event loop, we need to create
                 # a new session.

--- a/kr8s/_exceptions.py
+++ b/kr8s/_exceptions.py
@@ -4,3 +4,7 @@ class NotFoundError(Exception):
 
 class ConnectionClosedError(Exception):
     """A connection has been closed."""
+
+
+class APITimeoutError(Exception):
+    """A timeout has occurred while waiting for a response from the Kubernetes API server."""


### PR DESCRIPTION
While debugging #183 I found that the API would occasionally time out and I needed to retry in my code. Having a custom error made this a little easier to understand what was happening.