### PR TITLE
Remove cross-loop retries

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -158,20 +158,6 @@ class Api(object):
                 raise APITimeoutError(
                     "Timeout while waiting for the Kubernetes API server"
                 ) from e
-            except RuntimeError as e:
-                # If the client is reused on a different event loop, we need to create
-                # a new session.
-                if any(
-                    [
-                        "Event loop is closed" in str(e),
-                        "bound to a different event loop" in str(e),
-                        "attached to a different loop" in str(e),
-                    ]
-                ):
-                    await self._create_session()
-                    continue
-                else:
-                    raise
             break
 
     @contextlib.asynccontextmanager

--- a/kr8s/_io.py
+++ b/kr8s/_io.py
@@ -33,7 +33,7 @@ class Portal:
         if cls._instance is None:
             cls._instance = super(Portal, cls).__new__(cls)
             cls._instance.thread = Thread(
-                target=anyio.run, args=[cls._instance._run], name="kr8s-portal"
+                target=anyio.run, args=[cls._instance._run], name="Kr8sSyncRunnerThread"
             )
             cls._instance.thread.daemon = True
             cls._instance.thread.start()


### PR DESCRIPTION
Thanks to #188 we no longer need to reinitialise the session if the API client is reused from a different loop.