### PR TITLE
Remove sync wrapped call inside .get

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -167,7 +167,7 @@ class APIObject:
             if cls._asyncio:
                 api = await kr8s.asyncio.api()
             else:
-                api = kr8s.api()
+                api = await kr8s.asyncio.api(_asyncio=False)
         namespace = namespace if namespace else api.namespace
         start = time.time()
         backoff = 0.1

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -223,6 +223,21 @@ async def test_pod_get(example_pod_spec):
         await pod2.delete()
 
 
+def test_pod_get_sync(example_pod_spec):
+    pod = SyncPod(example_pod_spec)
+    pod.create()
+    with pytest.raises(kr8s.NotFoundError):
+        SyncPod.get(f"{pod.name}-foo", namespace=pod.namespace, timeout=0.1)
+    pod2 = SyncPod.get(pod.name, namespace=pod.namespace)
+    assert pod2.name == pod.name
+    assert pod2.namespace == pod.namespace
+    pod.delete()
+    while pod.exists():
+        time.sleep(0.1)
+    with pytest.raises(kr8s.NotFoundError):
+        pod2.delete()
+
+
 async def test_pod_from_name(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()


### PR DESCRIPTION
Closes #190 

With the changes in #188 we now have a single thread that gets reused for running coroutines synchronously. This means we now strictly cannot call wrapped sync functions from within coroutines as we cannot dispatch a coroutine to the loop of the current thread. 

Previously a new thread would be created to run the nested wrapped coroutine, which could result in threads spawned from threads spawned from threads... and this bug was never noticed.

It looks like we had a wrapped call in `APIObject.get` to create the API object. This PR adds a test for the sync `.get` method and fixes this nested call.