### PR TITLE
[wip] Implement pod exec functionality

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -757,16 +757,15 @@ class Pod(APIObject):
         # transport to SPDY or Websockets.
         with contextlib.supress(httpx.ReadTimeout):
             with self.api.call_api(
-                    "POST",
-                    url=f"{self.endpoint}/{self.name}/exec",
-                    namespace=self.namespace,
-                    params=params,
-                    stream=True,
-                    headers=headers,
+                "POST",
+                url=f"{self.endpoint}/{self.name}/exec",
+                namespace=self.namespace,
+                params=params,
+                stream=True,
+                headers=headers,
             ) as resp:
                 for line in resp.iter_lines():
                     yield line
-
 
     def portforward(self, remote_port: int, local_port: int = None) -> int:
         """Port forward a pod.


### PR DESCRIPTION
This is an attempt to solve https://github.com/kr8s-org/kr8s/issues/169 , unfortunately it got stuck due to limitations in the httpx library.

httpx does not support the "Connection: Upgrade" mechanism to switch the transport to SPDY or Websockets:

* https://github.com/encode/httpx/issues/1150
* https://github.com/encode/httpx/issues/304#issuecomment-670910032
* https://github.com/encode/httpx/discussions/1650

Here's an example of what `kubectl` does under the hood:
```
kubectl exec -n my-namespace my-pod -c my-container -v=8 -- cat /etc/passwd

I1020 08:02:52.688543    3744 round_trippers.go:463] POST https://1.2.3.4:6443/api/v1/namespaces/my-namespace/pods/my-pod/exec?command=cat+%2Fetc%2Fpasswd&container=my-container&stderr=true&stdout=true
I1020 08:02:52.688556    3744 round_trippers.go:469] Request Headers:
I1020 08:02:52.688563    3744 round_trippers.go:473]     X-Stream-Protocol-Version: v4.channel.k8s.io
I1020 08:02:52.688569    3744 round_trippers.go:473]     X-Stream-Protocol-Version: v3.channel.k8s.io
I1020 08:02:52.688574    3744 round_trippers.go:473]     X-Stream-Protocol-Version: v2.channel.k8s.io
I1020 08:02:52.688579    3744 round_trippers.go:473]     X-Stream-Protocol-Version: channel.k8s.io
I1020 08:02:52.688585    3744 round_trippers.go:473]     User-Agent: kubectl/v1.28.2 (linux/amd64) kubernetes/89a4ea3
I1020 08:02:59.791415    3744 round_trippers.go:574] Response Status: 101 Switching Protocols in 7102 milliseconds
I1020 08:02:59.791454    3744 round_trippers.go:577] Response Headers:
I1020 08:02:59.791468    3744 round_trippers.go:580]     Connection: Upgrade
I1020 08:02:59.791478    3744 round_trippers.go:580]     Upgrade: SPDY/3.1
I1020 08:02:59.791488    3744 round_trippers.go:580]     X-Stream-Protocol-Version: v4.channel.k8s.io

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
...
```

For more details about the communication protocol, I recommend having a look at this article: https://cloud.redhat.com/blog/executing-commands-in-pods-using-k8s-api