### PR TITLE
Improve flexibility when getting resources by name

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -78,16 +78,7 @@ async def get(
     kubernetes = await kr8s.asyncio.api()
     if all_namespaces:
         namespace = kr8s.ALL
-    api_resources = await kubernetes.api_resources()
     for kind in resources:
-        for api_resource in api_resources:
-            if (
-                kind == api_resource["name"]
-                or kind == api_resource["singularName"]
-                or ("shortNames" in api_resource and kind in api_resource["shortNames"])
-            ):
-                kind = api_resource["name"]
-                break
         response = await kubernetes.get(
             kind,
             namespace=namespace,

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Tuple, Union
 
 import aiohttp
 import httpx
-from async_lru import alru_cache
 
 from ._auth import KubeAuth
 from ._data_utils import dict_to_selector
@@ -394,7 +393,6 @@ class Api(object):
         """Get the Kubernetes API resources."""
         return await self._api_resources()
 
-    @alru_cache(ttl=30)
     async def _api_resources(self) -> dict:
         """Get the Kubernetes API resources."""
         resources = []

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1249,12 +1249,21 @@ def get_class(
             cls_group, cls_version = None, cls.version
         if (
             hasattr(cls, "kind")
-            and (cls.kind == kind or cls.singular == kind or cls.plural == kind)
-            and (group is None or cls_group == group)
-            and (version is None or cls_version == version)
             and cls._asyncio == _asyncio
+            and (cls.kind == kind or cls.singular == kind or cls.plural == kind)
         ):
-            return cls
+            if (group is None or cls_group == group) and (
+                version is None or cls_version == version
+            ):
+                return cls
+            if (
+                not version
+                and "." in group
+                and cls_group == group.split(".", 1)[1]
+                and cls_version == group.split(".", 1)[0]
+            ):
+                return cls
+
     raise KeyError(f"No object registered for {kind}{'.' + group if group else ''}")
 
 

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1259,7 +1259,7 @@ def get_class(
 
 
 def new_class(
-    kind: str, version: str = None, asyncio: bool = True, namespaced=True
+    kind: str, version: Optional[str] = None, asyncio: bool = True, namespaced=True
 ) -> Type[APIObject]:
     """Create a new APIObject subclass.
 
@@ -1272,6 +1272,8 @@ def new_class(
     Returns:
         A new APIObject subclass.
     """
+    if "." in kind:
+        kind, version = kind.split(".", 1)
     if version is None:
         version = "v1"
     return type(

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -247,3 +247,18 @@ def test_api_client_reuse_between_event_loops():
     asyncio.run(get_api())
     asyncio.set_event_loop(asyncio.new_event_loop())
     asyncio.run(get_api())
+
+
+async def test_api_names(example_pod_spec, ns):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    assert pod in await kr8s.asyncio.get("pods", namespace=ns)
+    assert pod in await kr8s.asyncio.get("pods/v1", namespace=ns)
+    assert pod in await kr8s.asyncio.get("Pod", namespace=ns)
+    assert pod in await kr8s.asyncio.get("pod", namespace=ns)
+    assert pod in await kr8s.asyncio.get("po", namespace=ns)
+    await pod.delete()
+
+    await kr8s.asyncio.get("roles", namespace=ns)
+    await kr8s.asyncio.get("roles.rbac.authorization.k8s.io", namespace=ns)
+    await kr8s.asyncio.get("roles.rbac.authorization.k8s.io/v1", namespace=ns)

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -261,4 +261,5 @@ async def test_api_names(example_pod_spec, ns):
 
     await kr8s.asyncio.get("roles", namespace=ns)
     await kr8s.asyncio.get("roles.rbac.authorization.k8s.io", namespace=ns)
+    await kr8s.asyncio.get("roles.v1.rbac.authorization.k8s.io", namespace=ns)
     await kr8s.asyncio.get("roles.rbac.authorization.k8s.io/v1", namespace=ns)

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -20,7 +20,7 @@ from kr8s.asyncio.objects import (
 )
 from kr8s.asyncio.portforward import PortForward
 from kr8s.objects import Pod as SyncPod
-from kr8s.objects import get_class, object_from_spec
+from kr8s.objects import get_class, new_class, object_from_spec
 
 DEFAULT_TIMEOUT = httpx.Timeout(30)
 CURRENT_DIR = pathlib.Path(__file__).parent
@@ -413,6 +413,15 @@ async def test_subclass_registration():
         namespaced = True
 
     get_class("MyResource", "foo.kr8s.org/v1alpha1")
+
+
+async def test_new_class_registration():
+    with pytest.raises(KeyError):
+        get_class("MyOtherResource", "foo.kr8s.org/v1alpha1")
+
+    MyOtherResource = new_class("MyOtherResource.foo.kr8s.org/v1alpha1")  # noqa: F841
+
+    get_class("MyOtherResource", "foo.kr8s.org/v1alpha1")
 
 
 async def test_deployment_scale(example_deployment_spec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "aiohttp>=3.8.4",
-    "async-lru>=2",
     "pyyaml>=6.0",
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "aiohttp>=3.8.4",
+    "async-lru>=2",
     "pyyaml>=6.0",
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",


### PR DESCRIPTION
Closes #196 

This PR makes many general improvements to `kr8s._objects.get_class` to enable looking up classes from various strings. Previously this had only been implemented in`kubectl-ng` so this PR pushes that down into `kr8s` and also adds more flexibility.

The outcome is that when using `kr8s.get(resource)` the resource now supports the formats `KIND[.GROUP][/VERSION]` or `KIND[.VERSION][.GROUP]` where `KIND` can be singular, plural, titlecase or a short name.

### Examples

```python
import kr8s

pods = kr8s.get("pods")  # Only this worked previously
pods = kr8s.get("pod")  # Singular
pods = kr8s.get("Pod")  # Title
pods = kr8s.get("po")  # Short name
pods = kr8s.get("pods/v1")  # Explicit version
```

For resources that have an API group such as `roles.rbac.authorization.k8s.io/v1` we can also select that in various ways.

```python
import kr8s

roles = kr8s.get("roles")  # Only this worked previously
roles = kr8s.get("role")  # Singular
roles = kr8s.get("Role")  # Title
roles = kr8s.get("roles.rbac.authorization.k8s.io")  # Full group name
roles = kr8s.get("roles.rbac.authorization.k8s.io/v1")  # Full group name with explicit version
roles = kr8s.get("roles.v1.rbac.authorization.k8s.io")  # Full group name with explicit version alternative
```
