### PR TITLE
Find latest available kind image for each supported version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,8 +21,6 @@ jobs:
             kubernetes-version: 1.27.3
           - python-version: '3.10'
             kubernetes-version: 1.26.6
-          - python-version: '3.10'
-            kubernetes-version: 1.25.11
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Read the Docs](https://img.shields.io/readthedocs/kr8s?logo=readthedocs&logoColor=white)](https://kr8s.readthedocs.io/en/latest/?badge=latest)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kr8s)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.25%7C1.26%7C1.27%7C1.28-blue)](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.26%7C1.27%7C1.28-blue)](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kr8s)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.25%7C1.26%7C1.27%7C1.28-blue)](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.26%7C1.27%7C1.28-blue)](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 <iframe src="https://ghbtns.com/github-btn.html?user=kr8s-org&repo=kr8s&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>


### PR DESCRIPTION
The `.github/workflows/update-kubernetes.yaml` workflow runs a script every night that looks up the latest supported versions of Kubernetes and then opens a PR to update README/docs badges and CI configuration to test against those versions.

However, we use `kind` for our testing and there usually isn't a `kindest/node` container image for the latest patch release of each version cycle. E.g at the time of writing the latest version of Kubernetes is `1.28.3` but the latest `kindest/node` tag is `1.28.0`, for `1.27` the latest patch is `1.27.7` but the latest `kindest/node` tag is `1.27.3`.

This PR updates the script to also read the list of `kindest/node` tags from Docker Hub and select the most recent image for each minor version patch release instead of using the latest patch release information.

I've also run the script which has removed `1.25` altogether because it is now EOL.