### PR TITLE
Add support for JSON 6902 style patching

### DIFF
--- a/docs/examples/modifying_resources.md
+++ b/docs/examples/modifying_resources.md
@@ -74,7 +74,7 @@ pod.patch(
 ```python
 from kr8s.asyncio.objects import Pod
 
-pod = Pod("my-pod", namespace="kube-system")
+pod = await Pod("my-pod", namespace="kube-system")
 await pod.patch(
     [{"op": "replace", "path": "/metadata/labels", "value": {"patched": "true"}}],
     type="json",

--- a/docs/examples/modifying_resources.md
+++ b/docs/examples/modifying_resources.md
@@ -52,6 +52,38 @@ await pod.label({"foo": "bar"})
 
 `````
 
+## Replace all Pod labels
+
+Using the JSON 6902 style patching replace all Pod labels with `{"patched": "true"}`.
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+from kr8s.objects import Pod
+
+pod = Pod("my-pod", namespace="kube-system")
+pod.patch(
+    [{"op": "replace", "path": "/metadata/labels", "value": {"patched": "true"}}],
+    type="json",
+)
+```
+````
+
+````{tab-item} Async
+```python
+from kr8s.asyncio.objects import Pod
+
+pod = Pod("my-pod", namespace="kube-system")
+await pod.patch(
+    [{"op": "replace", "path": "/metadata/labels", "value": {"patched": "true"}}],
+    type="json",
+)
+```
+````
+
+`````
+
 ## Cordon a Node
 
 Cordon a Node to mark it as unschedulable.

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -376,7 +376,7 @@ async def test_patch_pod_json(example_pod_spec):
         [{"op": "replace", "path": "/metadata/labels", "value": {"patched": "true"}}],
         type="json",
     )
-    assert "patched" in pod.labels
+    assert set(pod.labels) == {"patched"}
     await pod.delete()
 
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -368,6 +368,18 @@ async def test_patch_pod(example_pod_spec):
     await pod.delete()
 
 
+async def test_patch_pod_json(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    assert "patched" not in pod.labels
+    await pod.patch(
+        [{"op": "replace", "path": "/metadata/labels", "value": {"patched": "true"}}],
+        type="json",
+    )
+    assert "patched" in pod.labels
+    await pod.delete()
+
+
 async def test_all_v1_objects_represented():
     kubernetes = await kr8s.asyncio.api()
     k8s_objects = await kubernetes.api_resources()


### PR DESCRIPTION
Closes #201.

Add support for JSON 6902 style patching by adding a `type=` kwarg to `APIObject.patch` to match the `kubectl` flag.

```bash
$ kubectl patch secret my-secret \
    -p='[{"op": "replace", "path": "/data", "value":{"bbb": "bW9yZV9leGFtcGxl"}}]' \
    --type='json' 
```

```python
>>> from kr8s.objects import Secret
>>> Secret("my-secret").patch(
...     [{"op": "replace", "path": "/data", "value": {"bbb": "bW9yZV9leGFtcGxl"}}],
...     type="json",
... )
```