### PR TITLE
If no stdout/stderr requested tell Kubernetes not to send it

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -776,10 +776,11 @@ class Pod(APIObject):
         command: List[str],
         *,
         container: str = None,
-        stdin: Union(str | BinaryIO) = None,
-        stdout: Union(str | BinaryIO) = None,
-        stderr: Union(str | BinaryIO) = None,
+        stdin: Union(str | bytes | BinaryIO) = None,
+        stdout: BinaryIO = None,
+        stderr: BinaryIO = None,
         check: bool = True,
+        capture_output: bool = True,
     ):
         ex = Exec(
             self,
@@ -789,6 +790,7 @@ class Pod(APIObject):
             stderr=stderr,
             stdin=stdin,
             check=check,
+            capture_output=capture_output,
         )
         async with ex.run() as process:
             await process.wait()
@@ -799,20 +801,22 @@ class Pod(APIObject):
         command: List[str],
         *,
         container: str = None,
-        stdin: Union(str | BinaryIO) = None,
-        stdout: Union(str | BinaryIO) = None,
-        stderr: Union(str | BinaryIO) = None,
+        stdin: Union(str | bytes | BinaryIO) = None,
+        stdout: BinaryIO = None,
+        stderr: BinaryIO = None,
         check: bool = True,
+        capture_output: bool = True,
     ):
         """Run a command in a container and wait until it completes.
 
         Args:
             command: Command to execute.
             container: Container to execute the command in.
-            stdin: If True, pass stdin to the container.
-            stdout: If True, capture stdout from the container.
-            stderr: If True, capture stderr from the container.
+            stdin: If set, read stdin to the container.
+            stdout: If set, write stdout to the provided writable stream object.
+            stderr: If set, write stderr to the provided writable stream object.
             check: If True, raise an exception if the command fails.
+            capture_output: If True, store stdout and stderr from the container in an attribute.
         """
         return await self._exec(
             command,
@@ -821,6 +825,7 @@ class Pod(APIObject):
             stdout=stdout,
             stderr=stderr,
             check=check,
+            capture_output=capture_output,
         )
 
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -744,9 +744,10 @@ async def test_pod_exec_error(ubuntu_pod):
 
 async def test_pod_exec_to_file(ubuntu_pod):
     with tempfile.TemporaryFile(mode="w+b") as tmp:
-        await ubuntu_pod.exec(["date"], stdout=tmp)
+        exc = await ubuntu_pod.exec(["date"], stdout=tmp, capture_output=False)
         tmp.seek(0)
         assert str(datetime.datetime.now().year) in tmp.read().decode()
+        assert exc.stdout == b""
 
     with tempfile.TemporaryFile(mode="w+b") as tmp:
         with pytest.raises(ExecError):


### PR DESCRIPTION
In cases where you want to write stdout from an exec to a file you may want to avoid also storing that output in the `stdout` attributed. Especially in cases where this will be large. This PR adds a `capture_output` kwarg to disable this. 

> [!Note]
> This behaviour is the inverse of `subprocess.run()` which disables capturing by default.

```python
import kr8s, tempfile

pod = kr8s.objects.Pod.get("my-pod")

with tempfile.TemporaryFile(mode="w+b") as tmp:
    pod.exec(["date"], stdout=tmp, capture_output=False)
```