### PR TITLE
General documentation improvements

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -6,21 +6,54 @@ The core goals of `kr8s` are to be readable, beginner-friendly, batteries-includ
 
 This page is intended to highlight the differences between `kr8s` and other libraries to help you make good choices about which library is best for your project.
 
-```{warning}
-These comparions are subjective and certainly skewed in favour of `kr8s`. Take this information with a pinch of salt and be sure to do your own research.
+```{note}
+These comparisons have been put together with the best of intentions, but we acknowledge they are highly subjective and certainly skewed in favour of `kr8s`. Don't just take our word for it and be sure to do your own research.
 
-If you spot any information on this page that you beleive to be incorrect or incomplete please don't hesitate to [open a Pull Request](https://github.com/kr8s-org/kr8s/edit/main/docs/alternatives.md).
+If you spot any information on this page that you beleive to be incorrect or incomplete please don't hesitate to [open a Pull Request](https://github.com/kr8s-org/kr8s/edit/main/docs/alternatives.md). Our goal is to provide you with all the information you need to make the right choice for your needs.
 ```
 
 ## Comparison Table
 
-| Name                  | Sync | Asyncio | Repo Stars  | PyPI Downloads |
-| --------------------- | ---- | ------- | ----------- | -------------- |
-| [`kr8s`](https://github.com/kr8s-org/kr8s) | ✅ | ✅ | ![GitHub Repo stars](https://img.shields.io/github/stars/kr8s-org/kr8s) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/kr8s) |
-| [`kubernetes`](https://github.com/kubernetes-client/python) | ✅ | ❌ | ![GitHub Repo stars](https://img.shields.io/github/stars/kubernetes-client/python) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/kubernetes) |
-| [`kubernetes-asyncio`](https://github.com/tomplus/kubernetes_asyncio) | ❌ | ✅ |  ![GitHub Repo stars](https://img.shields.io/github/stars/tomplus/kubernetes_asyncio) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/kubernetes-asyncio) |
-| [`pykube-ng`](https://pykube.readthedocs.io/en/latest/) | ✅ | ❌ | ![Gitea Repo Stars](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcodeberg.org%2Fapi%2Fv1%2Frepos%2Fhjacobs%2Fpykube-ng%2Fstargazers&query=%24.length&label=stars) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/pykube-ng) |
-| [`lightkube`](https://lightkube.readthedocs.io/en/stable/) | ✅ | ✅ |  ![GitHub Repo stars](https://img.shields.io/github/stars/gtsystem/lightkube) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/lightkube) |
+```{list-table}
+:header-rows: 1
+
+*   - Name
+    - Sync
+    - Asyncio
+    - Repo Stars
+    - Monthly PyPI Downloads
+    - Total conda-forge Downloads
+*   - [`kr8s`](https://github.com/kr8s-org/kr8s)
+    - ✅
+    - ✅
+    - [![GitHub Repo stars](https://img.shields.io/github/stars/kr8s-org/kr8s)](https://github.com/kr8s-org/kr8s/stargazers)
+    - [![PyPI - Downloads](https://img.shields.io/pypi/dm/kr8s)](https://pypistats.org/packages/kr8s)
+    - ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/kr8s)
+*   - [`kubernetes`](https://github.com/kubernetes-client/python)
+    - ✅
+    - ❌
+    - [![GitHub Repo stars](https://img.shields.io/github/stars/kubernetes-client/python)](https://github.com/kubernetes-client/python/stargazers)
+    - [![PyPI - Downloads](https://img.shields.io/pypi/dm/kubernetes)](https://pypistats.org/packages/kubernetes)
+    - ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/kubernetes)
+*   - [`kubernetes-asyncio`](https://github.com/tomplus/kubernetes_asyncio)
+    - ❌
+    - ✅
+    - [![GitHub Repo stars](https://img.shields.io/github/stars/tomplus/kubernetes_asyncio)](https://github.com/tomplus/kubernetes_asyncio/stargazers)
+    - [![PyPI - Downloads](https://img.shields.io/pypi/dm/kubernetes-asyncio)](https://pypistats.org/packages/kubernetes-asyncio)
+    - ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/kubernetes_asyncio)
+*   - [`pykube-ng`](https://pykube.readthedocs.io/en/latest/)
+    - ✅
+    - ❌
+    - [![Gitea Repo Stars](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcodeberg.org%2Fapi%2Fv1%2Frepos%2Fhjacobs%2Fpykube-ng%2Fstargazers&query=%24.length&label=stars)](https://codeberg.org/hjacobs/pykube-ng/stars)
+    - [![PyPI - Downloads](https://img.shields.io/pypi/dm/pykube-ng)](https://pypistats.org/packages/pykube-ng)
+    - ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pykube-ng)
+*   - [`lightkube`](https://lightkube.readthedocs.io/en/stable/)
+    - ✅
+    - ✅
+    - [![GitHub Repo stars](https://img.shields.io/github/stars/gtsystem/lightkube)](https://github.com/gtsystem/lightkube/stargazers)
+    - [![PyPI - Downloads](https://img.shields.io/pypi/dm/lightkube)](https://pypistats.org/packages/lightkube)
+    - ![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/lightkube)
+```
 
 ## Direct Comparisons
 
@@ -30,11 +63,8 @@ The official `kubernetes` library maps exactly onto the Kubernetes API due to au
 
 In contrast `kr8s` may not have 100% API coverage with the Kubernetes API but the library is written to be very clear and readable which generally improves code quality. You can also use the [low-level API](client) to fill in any missing API gaps that you may need.
 
-Here's an example comparing listing all Pods using a label selector:
+Here's an example comparing listing all Pods using a label selector with `kr8s`:
 
-`````{tab-set}
-
-````{tab-item} kr8s
 ```python
 import kr8s
 
@@ -43,9 +73,9 @@ selector = {'component': 'kube-scheduler'}
 for pod in kr8s.get("pods", namespace=kr8s.ALL, label_selector=selector):
     print(pod.namespace, pod.name)
 ```
-````
 
-````{tab-item} kubernetes
+And here's the same example with `kubernetes`:
+
 ```python
 from kubernetes import client, config
 
@@ -58,30 +88,24 @@ v1 = client.CoreV1Api()
 for pods in v1.list_pod_for_all_namespaces(label_selector=selector_str, ).items:
     print(pod.metadata.namespace, pod.metadata.name)
 ```
-````
-
-`````
 
 ### `kr8s` vs `kubernetes_asyncio`
 
-The official `kubernetes` library doesn't support asyncio so the `kubernetes_asyncio` exists to fill that gap. It is created in the same way by auto generating a library using an asyncio OpenAPI generator.
+The official `kubernetes` library doesn't support asyncio so the `kubernetes_asyncio` library exists to fill that gap. It is created in the same way by auto generating a library using an asyncio OpenAPI generator.
 
 The code that is needed to use this library is the most verbose out of all of the libraries due to the use of async context managers for HTTP sessions and the documentation is even more minimal than the official library. Often developers need to look at the official docs and then try and translate it into `kubernetes_asyncio` code.
 
-Here's an example of listing the Nodes in your cluster:
+Here's an example of listing the Nodes in your cluster with `kr8s`:
 
-`````{tab-set}
-
-````{tab-item} kr8s (async)
 ```python
 import kr8s.asyncio
 
 for node in await kr8s.asyncio.get("nodes"):
     print(node.name)
 ```
-````
 
-````{tab-item} kubernetes_asyncio
+And here's the same example with `kubernetes-asyncio`:
+
 ```python
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client.api_client import ApiClient
@@ -94,19 +118,13 @@ async with ApiClient() as api:
     for node in nodes.items:
         print(node.metadata.name)
 ```
-````
-
-`````
 
 ### `kr8s` vs `pykube-ng`
 
-`pykube-ng` is a maintained fork of `pykube` which aims to be a lightweight and pythonic client. It uses no code generation and produces more readable code but doesn't support asyncio. It also has a very object driven API which can result in overly complex looking queries to do simple things like get a single resource.
+`pykube-ng` is a maintained fork of `pykube` which aims to be a lightweight and pythonic client. It uses no code generation and produces more readable code but doesn't support asyncio. It also has a very object driven API that appears to be inspired by [SQLAlchemy](https://www.sqlalchemy.org/) which can result in overly complex looking queries to do simple things like get a single resource.
 
-Here's an example listing ready Pods:
+Here's an example listing ready Pods with `kr8s`:
 
-`````{tab-set}
-
-````{tab-item} kr8s
 ```python
 import kr8s
 
@@ -114,9 +132,9 @@ for pod in kr8s.get("pods", namespace="kube-system"):
     if pod.ready():
         print(pod.name)
 ```
-````
 
-````{tab-item} pykube-ng
+And here's the same example with `pykube-ng`:
+
 ```python
 import pykube
 
@@ -125,9 +143,6 @@ for pod in pykube.Pod.objects(api).filter(namespace="kube-system"):
     if pod.ready:
         print(pod.name)
 ```
-````
-
-`````
 
 ### `kr8s` vs `lightkube`
 
@@ -135,20 +150,17 @@ Lightkube feels like the Typescript of the Python Kubernetes Client landscape. I
 
 It feels like the API client that `kubernetes` + `kubernetes_asyncio` could've been. This is a different design goal to `kr8s` which is trying to replicate the `kubectl` experience in Python rather than exposing the Kubernetes HTTP API.
 
-Here's an example of scaling a Deployment:
+Here's an example of scaling a Deployment with `kr8s`:
 
-`````{tab-set}
-
-````{tab-item} kr8s
 ```python
 from kr8s.objects import Deployment
 
 deploy = Deployment("metrics-server", namespace="kube-system")
 deploy.scale(1)
 ```
-````
 
-````{tab-item} lightkube
+And here's the same example with `lightkube`:
+
 ```python
 from lightkube import Client
 from lightkube.resources.apps_v1 import Deployment
@@ -156,12 +168,9 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.models.autoscaling_v1 import ScaleSpec
 
 client = Client()
-obj = Deployment.Scale(
+deploy = Deployment.Scale(
     metadata=ObjectMeta(name='metrics-server', namespace='kube-system'),
     spec=ScaleSpec(replicas=1)
 )
-client.replace(obj)
+client.replace(deploy)
 ```
-````
-
-`````

--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -2,7 +2,7 @@
 
 ## Create a Pod
 
-Create a new Pod.
+Create a new {py:class}`Pod <kr8s.objects.Pod>`.
 
 `````{tab-set}
 
@@ -48,7 +48,7 @@ await pod.create()
 
 ## Create a Secret
 
-Create a Secret with several keys.
+Create a {py:class}`Secret <kr8s.objects.Secret>` with several keys.
 
 `````{tab-set}
 

--- a/docs/examples/inspecting_resources.md
+++ b/docs/examples/inspecting_resources.md
@@ -2,7 +2,7 @@
 
 ## Reading Pod logs
 
-Print out the logs from a Pod.
+Print out the logs from a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.logs() <kr8s.objects.Pod.logs()>`.
 
 `````{tab-set}
 
@@ -31,7 +31,7 @@ async for line in pod.logs():
 
 ## Follow Pod logs until a timeout
 
-Print out all the logs from a Pod and keep following until a timeout or the Pod is deleted.
+Print out all the logs from a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.logs() <kr8s.objects.Pod.logs()>` and keep following until a timeout or the Pod is deleted.
 
 `````{tab-set}
 

--- a/docs/examples/labelling_operator.md
+++ b/docs/examples/labelling_operator.md
@@ -1,6 +1,6 @@
 # Labelling Operator
 
-Build an operator that periodically reconciles all Deployments and adds a label to any with a certain annotation.
+Build an operator that periodically reconciles all {py:class}`Deployments <kr8s.objects.Deployment>` and adds a label to any with a certain annotation.
 
 ```{warning}
 While you can build operators with `kr8s` we would recommend folks look at using [kopf](https://kopf.readthedocs.io/en/stable/) for building anything more complex than the below example.
@@ -9,6 +9,11 @@ While you can build operators with `kr8s` we would recommend folks look at using
 ## Controller
 
 First we need to create a Python script called `controller.py` containing the controller code that uses `kr8s`.
+
+This script runs a [reconciliation loop](https://developers.redhat.com/articles/2021/06/22/kubernetes-operators-101-part-2-how-operators-work)
+that periodically lists all {py:class}`Deployments <kr8s.objects.Deployment>` with {py:func}`kr8s.get()`.
+It then checks the {py:func}`Deployment.annotations <kr8s.objects.Deployment.annotations>` property and if it has the annotation `pykube-test-operator` it adds the label `foo=bar` using
+{py:func}`Deployment.label() <kr8s.objects.Deployment.label()>`.
 
 `````{tab-set}
 

--- a/docs/examples/listing_resources.md
+++ b/docs/examples/listing_resources.md
@@ -2,7 +2,7 @@
 
 ## List Nodes
 
-Print out all of the node names in the cluster.
+Print out all of the {py:class}`Node <kr8s.objects.Node>` names in the cluster using {py:func}`kr8s.get()`.
 
 `````{tab-set}
 
@@ -28,7 +28,7 @@ for node in await kr8s.asyncio.get("nodes"):
 
 ## List Pods in all Namespaces
 
-List all Pods in all namespaces and print their IP, namespace and name.
+List all Pods in all namespaces with {py:func}`kr8s.get()` and print their IP, namespace and name.
 
 `````{tab-set}
 
@@ -54,7 +54,7 @@ for pod in await kr8s.asyncio.get("pods", namespace=kr8s.ALL):
 
 ## List Ingresses (all styles)
 
-List all Ingresses in the current namespace using all styles from shorthand to explicit group and version naming.
+List all {py:class}`Ingresses <kr8s.objects.Ingress>` in the current namespace with {py:func}`kr8s.get()` using all styles from shorthand to explicit group and version naming.
 
 `````{tab-set}
 
@@ -91,7 +91,7 @@ ings = await kr8s.asyncio.get("ingress.networking.k8s.io/v1")  # Full with expli
 `````
 ## List Ready Pods
 
-Get a list of Pod resources that have the `Ready=True` condition.
+Get a list of {py:class}`Pod <kr8s.objects.Pod>` resources that have the `Ready=True` condition using {py:func}`kr8s.get()`.
 
 `````{tab-set}
 
@@ -119,7 +119,7 @@ for pod in await kr8s.asyncio.get("pods", namespace="kube-system"):
 
 ## List Pods by label selector
 
-Starting from a dictionary containing a label selector get all Pods from all Namespaces matching that label.
+Starting from a dictionary containing a label selector get all {py:class}`Pods <kr8s.objects.Pod>` from all Namespaces matching that label with {py:func}`kr8s.get()`.
 
 `````{tab-set}
 
@@ -149,7 +149,7 @@ for pod in await kr8s.asyncio.get("pods", namespace=kr8s.ALL, label_selector=sel
 
 ## List Running Pods
 
-Get a list of Pod resources that have `status.phase=Running` using a field selector.
+Get a list of {py:class}`Pod <kr8s.objects.Pod>` resources that have `status.phase=Running` using a field selector in {py:func}`kr8s.get()`.
 
 `````{tab-set}
 
@@ -175,7 +175,7 @@ for pod in await kr8s.asyncio.get("pods", namespace="kube-system", field_selecto
 
 ## List Pods sorted by restart count
 
-List Pods and sort them by their restart count.
+List {py:class}`Pods <kr8s.objects.Pod>` with {py:func}`kr8s.get()` and sort them by their restart count.
 
 `````{tab-set}
 

--- a/docs/examples/modifying_resources.md
+++ b/docs/examples/modifying_resources.md
@@ -2,7 +2,8 @@
 
 ## Scale a Deployment
 
-Scale the Deployment `metrics-server` in the Namespace `kube-system` to `1` replica.
+Scale the {py:class}`Depoyment <kr8s.objects.Deployment>` `metrics-server` using {py:func}`Deployment.scale() <kr8s.objects.Deployment.scale()>`
+in the Namespace `kube-system` to `1` replica.
 
 `````{tab-set}
 
@@ -28,7 +29,7 @@ await deploy.scale(1)
 
 ## Add a label to a Pod
 
-Add the label `foo` with the value `bar` to an existing Pod.
+Add the label `foo` with the value `bar` to an existing {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.label() <kr8s.objects.Pod.label()>`.
 
 `````{tab-set}
 
@@ -54,7 +55,7 @@ await pod.label({"foo": "bar"})
 
 ## Replace all Pod labels
 
-Using the JSON 6902 style patching replace all Pod labels with `{"patched": "true"}`.
+Using the [JSON 6902](https://jsonpatch.com/) style patching replace all {py:class}`Pod <kr8s.objects.Pod>` labels with `{"patched": "true"}` using {py:func}`Pod.patch() <kr8s.objects.Pod.patch()>`.
 
 `````{tab-set}
 
@@ -86,7 +87,7 @@ await pod.patch(
 
 ## Cordon a Node
 
-Cordon a Node to mark it as unschedulable.
+Cordon a {py:class}`Node <kr8s.objects.Node>` to mark it as unschedulable with {py:func}`Node.cordon() <kr8s.objects.Node.cordon()>`.
 
 `````{tab-set}
 

--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -2,7 +2,7 @@
 
 ## Exec a command
 
-Exec a command in a Pod.
+Exec a command in a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.exec() <kr8s.objects.Pod.exec()>`.
 
 `````{tab-set}
 
@@ -34,7 +34,7 @@ print(command.stdout.decode())
 
 ## Exec a command and redirect stdout/stderr
 
-Exec a command in a Pod and write the output to `sys.stdout` and `sys.stderr`.
+Run a command in a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.exec() <kr8s.objects.Pod.exec()>` and write the output to `sys.stdout` and `sys.stderr`.
 
 
 `````{tab-set}

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -43,9 +43,53 @@ class Api(_AsyncApi):
     __doc__ = _AsyncApi.__doc__
 
 
+def get(*args, **kwargs):
+    """Get a resource by name.
+
+    Parameters
+    ----------
+    kind : str
+        The kind of resource to get
+    *names : List[str]
+        The names of the resources to get
+    namespace : str, optional
+        The namespace to get the resource from
+    label_selector : Union[str, Dict], optional
+        The label selector to filter the resources by
+    field_selector : Union[str, Dict], optional
+        The field selector to filter the resources by
+    as_object : object, optional
+        The object to populate with the resource data
+    api : Api, optional
+        The api to use to get the resource
+
+    Returns
+    -------
+    object
+        The populated object
+
+    Raises
+    ------
+    ValueError
+        If the resource is not found
+
+    Examples
+    --------
+
+        >>> import kr8s
+        >>> # All of these are equivalent
+        >>> ings = kr8s.get("ing")                           # Short name
+        >>> ings = kr8s.get("ingress")                       # Singular
+        >>> ings = kr8s.get("ingresses")                     # Plural
+        >>> ings = kr8s.get("Ingress")                       # Title
+        >>> ings = kr8s.get("ingress.networking.k8s.io")     # Full group name
+        >>> ings = kr8s.get("ingress.v1.networking.k8s.io")  # Full with explicit version
+        >>> ings = kr8s.get("ingress.networking.k8s.io/v1")  # Full with explicit version alt.
+    """
+    return _run_sync(partial(_get, _asyncio=False))(*args, **kwargs)
+
+
 api = _run_sync(partial(_api, _asyncio=False))
-get = _run_sync(partial(_get, _asyncio=False))
-update_wrapper(get, _get)
 version = _run_sync(partial(_k8s_version, _asyncio=False))
 update_wrapper(version, _k8s_version)
 watch = _run_sync(partial(_watch, _asyncio=False))

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -395,7 +395,23 @@ class APIObject:
         await self._patch({"metadata": {"annotations": annotations}})
 
     async def label(self, labels: dict = None, **kwargs) -> None:
-        """Label this object in Kubernetes."""
+        """Add labels to this object in Kubernetes.
+
+        Labels can be passed as a dictionary or as keyword arguments.
+
+        Args:
+            labels:
+                A dictionary of labels to set.
+            **kwargs:
+                Labels to set.
+
+        Example:
+            >>> from kr8s.objects import Deployment
+            >>> deployment = Deployment.get("my-deployment")
+            >>> # Both of these are equivalent
+            >>> deployment.label({"app": "my-app"})
+            >>> deployment.label(app="my-app")
+        """
         if labels is None:
             labels = kwargs
         if not labels:
@@ -609,9 +625,17 @@ class Node(APIObject):
         return False
 
     async def cordon(self) -> None:
+        """Cordon the node.
+
+        This will mark the node as unschedulable.
+        """
         await self._patch({"spec": {"unschedulable": True}})
 
     async def uncordon(self) -> None:
+        """Uncordon the node.
+
+        This will mark the node as schedulable.
+        """
         await self._patch({"spec": {"unschedulable": False}})
 
 
@@ -678,16 +702,26 @@ class Pod(APIObject):
         """Streams logs from a Pod.
 
         Args:
-            container: The container to get logs from. Defaults to the first container in the Pod.
-            pretty: If True, return pretty logs. Defaults to False.
-            previous: If True, return previous terminated container logs. Defaults to False.
-            since_seconds: If set, return logs since this many seconds ago.
-            since_time: If set, return logs since this time.
-            timestamps: If True, prepend each log line with a timestamp. Defaults to False.
-            tail_lines: If set, return this many lines from the end of the logs.
-            limit_bytes: If set, return this many bytes from the end of the logs.
-            follow: If True, follow the logs until the timeout is reached. Defaults to False.
-            timeout: If following timeout after this many seconds. Set to None to disable timeout.
+            container:
+                The container to get logs from. Defaults to the first container in the Pod.
+            pretty:
+                If True, return pretty logs. Defaults to False.
+            previous:
+                If True, return previous terminated container logs. Defaults to False.
+            since_seconds:
+                If set, return logs since this many seconds ago.
+            since_time:
+                If set, return logs since this time.
+            timestamps:
+                If True, prepend each log line with a timestamp. Defaults to False.
+            tail_lines:
+                If set, return this many lines from the end of the logs.
+            limit_bytes:
+                If set, return this many bytes from the end of the logs.
+            follow:
+                If True, follow the logs until the timeout is reached. Defaults to False.
+            timeout:
+                If following timeout after this many seconds. Set to None to disable timeout.
 
         Returns:
             An async generator yielding log lines.
@@ -809,14 +843,33 @@ class Pod(APIObject):
     ):
         """Run a command in a container and wait until it completes.
 
+        Behaves like :func:`subprocess.run`.
+
         Args:
-            command: Command to execute.
-            container: Container to execute the command in.
-            stdin: If set, read stdin to the container.
-            stdout: If set, write stdout to the provided writable stream object.
-            stderr: If set, write stderr to the provided writable stream object.
-            check: If True, raise an exception if the command fails.
-            capture_output: If True, store stdout and stderr from the container in an attribute.
+            command:
+                Command to execute.
+            container:
+                Container to execute the command in.
+            stdin:
+                If set, read stdin to the container.
+            stdout:
+                If set, write stdout to the provided writable stream object.
+            stderr:
+                If set, write stderr to the provided writable stream object.
+            check:
+                If True, raise an exception if the command fails.
+            capture_output:
+                If True, store stdout and stderr from the container in an attribute.
+
+        Returns:
+            A :class:`kr8s._exec.CompletedExec` object.
+
+        Example:
+            >>> from kr8s.objects import Pod
+            >>> pod = Pod.get("my-pod")
+            >>> ex = await pod.exec(["ls", "-l"])
+            >>> print(ex.stdout)
+            >>> print(ex.stderr)
         """
         return await self._exec(
             command,

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -18,6 +18,48 @@ async def get(
     _asyncio=True,
     **kwargs,
 ):
+    """Get a resource by name.
+
+    Parameters
+    ----------
+    kind : str
+        The kind of resource to get
+    *names : List[str]
+        The names of the resources to get
+    namespace : str, optional
+        The namespace to get the resource from
+    label_selector : Union[str, Dict], optional
+        The label selector to filter the resources by
+    field_selector : Union[str, Dict], optional
+        The field selector to filter the resources by
+    as_object : object, optional
+        The object to populate with the resource data
+    api : Api, optional
+        The api to use to get the resource
+
+    Returns
+    -------
+    object
+        The populated object
+
+    Raises
+    ------
+    ValueError
+        If the resource is not found
+
+    Examples
+    --------
+
+        >>> import kr8s
+        >>> # All of these are equivalent
+        >>> ings = await kr8s.asyncio.get("ing")                           # Short name
+        >>> ings = await kr8s.asyncio.get("ingress")                       # Singular
+        >>> ings = await kr8s.asyncio.get("ingresses")                     # Plural
+        >>> ings = await kr8s.asyncio.get("Ingress")                       # Title
+        >>> ings = await kr8s.asyncio.get("ingress.networking.k8s.io")     # Full group name
+        >>> ings = await kr8s.asyncio.get("ingress.v1.networking.k8s.io")  # Full with explicit version
+        >>> ings = await kr8s.asyncio.get("ingress.networking.k8s.io/v1")  # Full with explicit version alt.
+    """
     if api is None:
         api = await _api(_asyncio=_asyncio)
     return await api._get(

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -197,33 +197,6 @@ async def test_ns(ns):
     assert api.namespace == "foo"
 
 
-async def test_docstrings():
-    assert (
-        kr8s.Api.get.__doc__
-        == kr8s.asyncio.Api.get.__doc__
-        == kr8s.get.__doc__
-        == kr8s.asyncio.get.__doc__
-    )
-    assert (
-        kr8s.Api.version.__doc__
-        == kr8s.asyncio.Api.version.__doc__
-        == kr8s.version.__doc__
-        == kr8s.asyncio.version.__doc__
-    )
-    assert (
-        kr8s.Api.watch.__doc__
-        == kr8s.asyncio.Api.watch.__doc__
-        == kr8s.watch.__doc__
-        == kr8s.asyncio.watch.__doc__
-    )
-    assert (
-        kr8s.Api.api_resources.__doc__
-        == kr8s.asyncio.Api.api_resources.__doc__
-        == kr8s.api_resources.__doc__
-        == kr8s.asyncio.api_resources.__doc__
-    )
-
-
 async def test_async_get_returns_async_objects():
     pods = await kr8s.asyncio.get("pods", namespace=kr8s.ALL)
     assert pods[0]._asyncio is True


### PR DESCRIPTION
This PR includes a bunch of general docs improvements:

- Typos and grammar fixes
- Switch from a markdown table to MyST list table in `alternatives.md`
- Removed tab groups and inlined code comparisons in `alternatives.md`
- Add lots of ``` `{py:func}kr8s.foo()` ``` references
- Improve some docstrings

I also removed a test that was asserting some docstring equality. I'm not sure we actually want to ensure these are identical as some are async and some are not. Also despite the `__doc__` being equal the Sphinx site wasn't rendering some of them correctly.