### PR TITLE
Add `PortForward.run_forever()`, add docs examples and fix sync API bug

### DIFF
--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -71,10 +71,6 @@ await pod.exec(["ls", "/"], stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, 
 
 Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and communicate with the application on the other side.
 
-```{tip}
-This also works with {py:class}`Service <kr8s.objects.Service>` objects.
-```
-
 `````{tab-set}
 
 ````{tab-item} Sync
@@ -107,13 +103,13 @@ async with pod.portforward(remote_port=1234) as local_port, httpx.AsyncClient() 
 
 `````
 
-## Open a port forward permanently
-
-Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and block. This is useful when you need to access the port forward from another process, like you would with `kubectl`.
-
 ```{tip}
 This also works with {py:class}`Service <kr8s.objects.Service>` objects.
 ```
+
+## Open a port forward permanently
+
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and block. This is useful when you need to access the port forward from another process, like you would with `kubectl`.
 
 `````{tab-set}
 
@@ -136,3 +132,7 @@ await pod.portforward(1234, local_port=5678).run_forever()
 ````
 
 `````
+
+```{tip}
+This also works with {py:class}`Service <kr8s.objects.Service>` objects.
+```

--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -69,7 +69,7 @@ await pod.exec(["ls", "/"], stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, 
 
 ## Open a port forward and communicate with the Pod
 
-Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and communicate with the application on the other side.
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.portforward() <kr8s.objects.Pod.portforward()>` and communicate with the application on the other side.
 
 `````{tab-set}
 
@@ -109,7 +109,7 @@ This also works with {py:class}`Service <kr8s.objects.Service>` objects.
 
 ## Open a port forward permanently
 
-Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and block. This is useful when you need to access the port forward from another process, like you would with `kubectl`.
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.portforward() <kr8s.objects.Pod.portforward()>` and block. This is useful when you need to access the port forward from another process, like you would with `kubectl`.
 
 `````{tab-set}
 

--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -66,3 +66,73 @@ await pod.exec(["ls", "/"], stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, 
 ````
 
 `````
+
+## Open a port forward and communicate with the Pod
+
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and communicate with the application on the other side.
+
+```{tip}
+This also works with {py:class}`Service <kr8s.objects.Service>` objects.
+```
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+import requests
+from kr8s.objects import Pod
+
+pod = Pod.get("my-pod")
+
+with pod.portforward(remote_port=1234) as local_port:
+    # Make an API request
+    resp = requests.get(f"http://localhost:{local_port}")
+    # Do something with the response
+```
+````
+
+````{tab-item} Async
+```python
+import httpx
+from kr8s.asyncio.objects import Pod
+
+pod = await Pod.get("my-pod")
+
+async with pod.portforward(remote_port=1234) as local_port, httpx.AsyncClient() as client:
+    # Make an API request
+    resp = await client.get(f"http://localhost:{local_port}")
+    # Do something with the response
+```
+````
+
+`````
+
+## Open a port forward permanently
+
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.port_forward() <kr8s.objects.Pod.port_forward()>` and block. This is useful when you need to access the port forward from another process, like you would with `kubectl`.
+
+```{tip}
+This also works with {py:class}`Service <kr8s.objects.Service>` objects.
+```
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+from kr8s.objects import Pod
+
+pod = Pod.get("my-pod")
+pod.portforward(1234, local_port=5678).run_forever()
+```
+````
+
+````{tab-item} Async
+```python
+from kr8s.asyncio.objects import Pod
+
+pod = await Pod.get("my-pod")
+await pod.portforward(1234, local_port=5678).run_forever()
+```
+````
+
+`````

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -113,7 +113,14 @@ class PortForward:
         self._bg_task = None
 
     async def run_forever(self) -> None:
-        """Run the port forward forever."""
+        """Run the port forward forever.
+
+        Example:
+            >>> pf = pod.portforward(remote_port=8888, local_port=8889)
+            >>> # or
+            >>> pf = PortForward(pod, remote_port=8888, local_port=8889)
+            >>> await pf.run_forever()
+        """
         async with self:
             await self.server.serve_forever()
 

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import random
 import socket
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING, BinaryIO
 
 import aiohttp
@@ -61,11 +61,12 @@ class PortForward:
     def __init__(
         self, resource: APIObject, remote_port: int, local_port: int = None
     ) -> None:
-        if sniffio.current_async_library() != "asyncio":
-            raise RuntimeError(
-                "PortForward only works with asyncio, "
-                "see https://github.com/kr8s-org/kr8s/issues/104"
-            )
+        with suppress(sniffio.AsyncLibraryNotFoundError):
+            if sniffio.current_async_library() != "asyncio":
+                raise RuntimeError(
+                    "PortForward only works with asyncio, "
+                    "see https://github.com/kr8s-org/kr8s/issues/104"
+                )
         self.server = None
         self.remote_port = remote_port
         self.local_port = local_port if local_port is not None else 0
@@ -101,7 +102,7 @@ class PortForward:
                 self.local_port = port
                 await self._bg_future
 
-        self._bg_task = asyncio.create_task(f())
+        self._bg_task = self._loop.create_task(f())
         while self.local_port == 0:
             await asyncio.sleep(0.1)
         return self.local_port
@@ -110,6 +111,11 @@ class PortForward:
         """Stop the background task."""
         self._bg_future.set_result(None)
         self._bg_task = None
+
+    async def run_forever(self) -> None:
+        """Run the port forward forever."""
+        async with self:
+            await self.server.serve_forever()
 
     @asynccontextmanager
     async def _run(self) -> int:


### PR DESCRIPTION
Added a `run_forever()` method to the `PortForward` object to indefinitely block and serve the port forward.

```python
from kr8s.objects import Pod

pod = Pod.get("my-pod")
pod.portforward(1234, local_port=5678).run_forever()
```

Also added some documentation examples which closes #217 and a couple of fixes to the way the loop is handles which closes #218.