### PR TITLE
For sync port forwards start a background thread

### DIFF
--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -136,3 +136,50 @@ await pod.portforward(1234, local_port=5678).run_forever()
 ```{tip}
 This also works with {py:class}`Service <kr8s.objects.Service>` objects.
 ```
+
+## Open a port forward in the background
+
+Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.portforward() <kr8s.objects.Pod.portforward()>` as a background task/thread.
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+from kr8s.objects import Pod
+
+pod = Pod.get("my-pod")
+pf = pod.portforward(remote_port=1234, local_port=5678)
+
+# Starts the port forward in a background thread
+pf.start()
+
+# Your other code goes here
+
+# Optionally stop the port forward thread (it will exit with Python anyway)
+pf.stop()
+```
+````
+
+````{tab-item} Async
+```python
+from kr8s.asyncio.objects import Pod
+
+pod = await Pod.get("my-pod")
+pf = pod.portforward(remote_port=1234, local_port=5678)
+
+# Starts the port forward in a background task
+await pf.start()
+
+# Your other code goes here
+# WARNING: Your code must be async and non-blocking as the port forward and your code are sharing the same event loop
+
+# Optionally stop the port forward task (it will exit with Python anyway)
+await pf.stop()
+```
+````
+
+`````
+
+```{tip}
+This also works with {py:class}`Service <kr8s.objects.Service>` objects.
+```

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -17,4 +17,3 @@ class PortForward(_PortForward):
     def stop(self):
         """Stop the background thread."""
         self.server.close()
-        self.server = None

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -1,3 +1,5 @@
+import threading
+
 from ._io import sync
 from ._portforward import PortForward as _PortForward
 
@@ -5,3 +7,14 @@ from ._portforward import PortForward as _PortForward
 @sync
 class PortForward(_PortForward):
     __doc__ = _PortForward.__doc__
+    _bg_thread = None
+
+    def start(self):
+        """Start a background thread with the port forward running."""
+        self._bg_thread = threading.Thread(target=self.run_forever, daemon=True)
+        self._bg_thread.start()
+
+    def stop(self):
+        """Stop the background thread."""
+        self.server.close()
+        self.server = None


### PR DESCRIPTION
When starting a port forward via the sync API there is no way to give the event loop space to run. This PR overrides the `start()` and `stop()` methods on the sync `PortForward()` to run things in a background thread.

```python
from kr8s.objects import Pod
p = Pod.get("test")
pf = p.portforward(80, 5678)
pf.start()

# Your other sync code goes here

# Optionally stop the port forward (it will be killed when Python exits anyway)
pf.stop()
```

xref #217