### PR TITLE
Add Pod.gen()

### DIFF
--- a/docs/examples/generating_resources.md
+++ b/docs/examples/generating_resources.md
@@ -6,6 +6,8 @@ In `kr8s` we aim to provide similar functionality with a `.gen()` method on some
 
 ## Generating a Pod
 
+Generate a simple {py:class}`Pod <kr8s.objects.Pod>` with a couple of keyword arguments using {py:func}`Pod.gen() <kr8s.objects.Pod.gen()>` and create it.
+
 `````{tab-set}
 
 ````{tab-item} Sync

--- a/docs/examples/generating_resources.md
+++ b/docs/examples/generating_resources.md
@@ -1,0 +1,29 @@
+# Generating resources
+
+With `kubectl` you can call commands like `kubectl run nginx --image=nginx` which will generate the spec for a Pod and create it. Or you can generate a service with `kubectl create service clusterip my-cs --tcp=5678:8080`.
+
+In `kr8s` we aim to provide similar functionality with a `.gen()` method on some objects which allow you to generate the spec of an object with a few keyword arguments.
+
+## Generating a Pod
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+from kr8s.objects import Pod
+
+pod = Pod.gen(name="example-1", image="nginx:latest")
+pod.create()
+```
+````
+
+````{tab-item} Async
+```python
+from kr8s.asyncio.objects import Pod
+
+pod = await Pod.gen(name="example-1", image="nginx:latest")
+await pod.create()
+```
+````
+
+`````

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -7,6 +7,7 @@ creating_resources
 listing_resources
 inspecting_resources
 modifying_resources
+generating_resources
 pod_operations
 labelling_operator
 ```

--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -66,3 +66,41 @@ def dict_to_selector(selector_dict: Dict) -> str:
         A Kubernetes selector string.
     """
     return ",".join(f"{k}={v}" for k, v in selector_dict.items())
+
+
+def xdict(*in_dict, **kwargs):
+    """Dictionary constructor that ignores None values.
+
+    Args:
+        in_dict : Dict
+            A dict to convert. Only one is allowed.
+        **kwargs
+            Keyword arguments to be converted to a dict.
+
+    Returns:
+        Dict
+            A dict with None values removed.
+
+    Raises:
+        ValueError
+            If more than one positional argument is passed, or if both a positional
+            argument and keyword arguments are passed.
+
+    Examples:
+        >>> xdict(foo="bar", baz=None)
+        {"foo": "bar"}
+
+        >>> xdict({"foo": "bar", "baz": None})
+        {"foo": "bar"}
+    """
+    if len(in_dict) > 1:
+        raise ValueError(
+            f"xdict expected at most 1 positional argument, got {len(in_dict)}"
+        )
+    if len(in_dict) == 1 and kwargs:
+        raise ValueError(
+            "xdict expected at most 1 positional argument, or multiple keyword arguments, got both"
+        )
+    if len(in_dict) == 1:
+        [kwargs] = in_dict
+    return {k: v for k, v in kwargs.items() if v is not None}

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -38,6 +38,8 @@ def test_xdict():
     assert xdict({"foo": "bar", "baz": "qux"}) == {"foo": "bar", "baz": "qux"}
     assert xdict({"foo": "bar", "baz": None}) == {"foo": "bar"}
     with pytest.raises(ValueError):
+        xdict({}, {})
+    with pytest.raises(ValueError):
         assert xdict({}, quux=None) == {
             "foo": "bar",
             "baz": "qux",

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
 # SPDX-License-Identifier: BSD 3-Clause License
+import pytest
 
-from kr8s._data_utils import dict_to_selector, dot_to_nested_dict, list_dict_unpack
+from kr8s._data_utils import (
+    dict_to_selector,
+    dot_to_nested_dict,
+    list_dict_unpack,
+    xdict,
+)
 
 
 def test_list_dict_unpack():
@@ -22,3 +28,17 @@ def test_dot_to_nested_dict():
 def test_dict_to_selector():
     assert dict_to_selector({"foo": "bar"}) == "foo=bar"
     assert dict_to_selector({"foo": "bar", "baz": "qux"}) == "foo=bar,baz=qux"
+
+
+def test_xdict():
+    assert xdict(foo="bar") == {"foo": "bar"}
+    assert xdict(foo="bar", baz=None) == {"foo": "bar"}
+    assert xdict(foo="bar", baz="qux") == {"foo": "bar", "baz": "qux"}
+    assert xdict(foo="bar", baz="qux", quux=None) == {"foo": "bar", "baz": "qux"}
+    assert xdict({"foo": "bar", "baz": "qux"}) == {"foo": "bar", "baz": "qux"}
+    assert xdict({"foo": "bar", "baz": None}) == {"foo": "bar"}
+    with pytest.raises(ValueError):
+        assert xdict({}, quux=None) == {
+            "foo": "bar",
+            "baz": "qux",
+        }

--- a/kr8s/tests/test_gen.py
+++ b/kr8s/tests/test_gen.py
@@ -1,0 +1,32 @@
+import time
+
+from kr8s.objects import Pod
+
+
+def test_gen_pod(ns):
+    pod = Pod.gen(
+        name="foo",
+        namespace=ns,
+        image="nginx",
+        labels={"app": "foo"},
+        annotations={"bar": "baz"},
+    )
+    assert isinstance(pod, Pod)
+    assert pod.name == "foo"
+    assert pod.namespace == ns
+    assert pod.spec.containers[0].image == "nginx"
+    assert "app" in pod.labels
+    assert "bar" in pod.annotations
+    pod.create()
+    while not pod.exists():
+        time.sleep(1)
+    pod.delete()
+
+
+def test_gen_simple_pod(ns):
+    pod = Pod.gen(name="foo", image="nginx")  # Minimum arguments you can pass
+    pod.namespace = ns  # We need to set the namespace to avoid collisions in tests
+    pod.create()
+    while not pod.exists():
+        time.sleep(1)
+    pod.delete()


### PR DESCRIPTION
With `kubectl` you can call commands like `kubectl run nginx --image=nginx` which will generate the spec for a Pod and create it. Or you can generate a service with `kubectl create service clusterip my-cs --tcp=5678:8080`.

This PR adds similar functionality with a `.gen()` method on `Pod` which allows you to generate the spec of a Pod object with a few keyword arguments. We can easily extend this for other objects in the future.

```python
from kr8s.objects import Pod

pod = Pod.gen(name="example-1", image="nginx:latest")
pod.create()
```

xref #142 