### PR TITLE
Handle the port forward being cancelled

### DIFF
--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import random
 import socket
 from contextlib import asynccontextmanager, suppress
@@ -122,7 +123,8 @@ class PortForward:
             >>> await pf.run_forever()
         """
         async with self:
-            await self.server.serve_forever()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.server.serve_forever()
 
     @asynccontextmanager
     async def _run(self) -> int:

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 from ._io import sync
 from ._portforward import PortForward as _PortForward
@@ -16,4 +17,6 @@ class PortForward(_PortForward):
 
     def stop(self):
         """Stop the background thread."""
+        while self.server is None:
+            time.sleep(0.1)
         self.server.close()


### PR DESCRIPTION
It's ok for `serve_forever` to be cancelled.

Also added a little sleep to handle calling `pf.start()` and `pf.stop()` in quick succession.