### PR TITLE
Support converting objects to dicts

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -485,6 +485,10 @@ class APIObject:
         """
         await child._set_owner(self)
 
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of this object."""
+        return self.raw
+
     def to_lightkube(self) -> Any:
         """Return a lightkube representation of this object."""
         try:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -720,6 +720,13 @@ async def test_cast_to_from_pykube_ng(example_pod_spec):
     assert pykube_pod.namespace == example_pod_spec["metadata"]["namespace"]
 
 
+async def test_to_dict(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    to_spec = pod.to_dict()
+    assert to_spec == example_pod_spec
+    assert isinstance(to_spec, dict)
+
+
 async def test_pod_exec(ubuntu_pod):
     ex = await ubuntu_pod.exec(["date"])
     assert isinstance(ex, CompletedExec)


### PR DESCRIPTION
Libraries like `kubernetes`, `kubernetes_asyncio` and `lightkube` have a `to_dict()` method on their objects. We use this to convert to `kr8s` objects already. We should probably support this same API in case other libraries want to convert `kr8s` objects to dicts.

```python
from kr8s.objects import Pod

pod = Pod(...)

spec = pod.to_dict()
# is equivalent to the kr8s specific `spec = pod.raw`