### PR TITLE
Add schema validation example

### DIFF
--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -103,13 +103,14 @@ await secret.create()
 Validate the schema of a {py:class}`Pod <kr8s.objects.Pod>` before creating it.
 
 ```{info}
-By default `kr8s` does not perform client-side validation of object schemas, instead it behaves like `kubectl` and relies on server-side validation. However, if you have the [`kubernetes-validate`](https://pypi.org/project/kubernetes-validate/) package installed you can use the {py:func}`.validate() <kr8s.objects.Pod.validate()>` convenience method on any object to check it yourself.
+`kr8s` does not perform client-side validation of object schemas, instead it behaves like `kubectl` and relies on server-side validation. However, if you have the [`kubernetes-validate`](https://pypi.org/project/kubernetes-validate/) package installed you can easily check it yourself.
 ```
 
 `````{tab-set}
 
 ````{tab-item} Sync
 ```python
+import kubernetes_validate
 from kr8s.objects import Pod
 
 pod = Pod({
@@ -123,13 +124,14 @@ pod = Pod({
         },
     })
 
-pod.validate("1.28")
+kubernetes_validate.validate(pod.raw, "1.28")
 pod.create()
 ```
 ````
 
 ````{tab-item} Async
 ```python
+import kubernetes_validate
 from kr8s.asyncio.objects import Pod
 
 pod = await Pod({
@@ -143,9 +145,14 @@ pod = await Pod({
         },
     })
 
-await pod.validate("1.28")
+kubernetes_validate.validate(pod.raw, "1.28")
 await pod.create()
 ```
 ````
 
 `````
+
+
+```{note}
+If [willthames/kubernetes-validate#23](https://github.com/willthames/kubernetes-validate/pull/23) is accepted we can pass the Pod directly to `kubernetes_validate.validate()`.
+```

--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -102,7 +102,7 @@ await secret.create()
 
 Validate the schema of a {py:class}`Pod <kr8s.objects.Pod>` before creating it.
 
-```{info}
+```{hint}
 `kr8s` does not perform client-side validation of object schemas, instead it behaves like `kubectl` and relies on server-side validation. However, if you have the [`kubernetes-validate`](https://pypi.org/project/kubernetes-validate/) package installed you can easily check it yourself.
 ```
 
@@ -153,6 +153,6 @@ await pod.create()
 `````
 
 
-```{note}
+```{seealso}
 If [willthames/kubernetes-validate#23](https://github.com/willthames/kubernetes-validate/pull/23) is accepted we can pass the Pod directly to `kubernetes_validate.validate()`.
 ```

--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -97,3 +97,55 @@ await secret.create()
 ````
 
 `````
+
+## Validate a Pod
+
+Validate the schema of a {py:class}`Pod <kr8s.objects.Pod>` before creating it.
+
+```{info}
+By default `kr8s` does not perform client-side validation of object schemas, instead it behaves like `kubectl` and relies on server-side validation. However, if you have the [`kubernetes-validate`](https://pypi.org/project/kubernetes-validate/) package installed you can use the {py:func}`.validate() <kr8s.objects.Pod.validate()>` convenience method on any object to check it yourself.
+```
+
+`````{tab-set}
+
+````{tab-item} Sync
+```python
+from kr8s.objects import Pod
+
+pod = Pod({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "my-pod",
+        },
+        "spec": {
+            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause",}]
+        },
+    })
+
+pod.validate("1.28")
+pod.create()
+```
+````
+
+````{tab-item} Async
+```python
+from kr8s.asyncio.objects import Pod
+
+pod = await Pod({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "my-pod",
+        },
+        "spec": {
+            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause",}]
+        },
+    })
+
+await pod.validate("1.28")
+await pod.create()
+```
+````
+
+`````

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -423,17 +423,6 @@ class APIObject:
             raise ValueError("No labels provided")
         await self._patch({"metadata": {"labels": labels}})
 
-    async def validate(self, desired_version: str, strict: bool = False):
-        try:
-            import kubernetes_validate
-        except ImportError:
-            raise ImportError(
-                f"{self.__class__.__name__}.validate() requires kubernetes-validate to be installed"
-            )
-        return kubernetes_validate.validate(
-            self.raw, desired_version=desired_version, strict=strict
-        )
-
     def keys(self) -> list:
         """Return the keys of this object."""
         return self.raw.keys()

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -423,6 +423,17 @@ class APIObject:
             raise ValueError("No labels provided")
         await self._patch({"metadata": {"labels": labels}})
 
+    async def validate(self, desired_version: str, strict: bool = False):
+        try:
+            import kubernetes_validate
+        except ImportError:
+            raise ImportError(
+                f"{self.__class__.__name__}.validate() requires kubernetes-validate to be installed"
+            )
+        return kubernetes_validate.validate(
+            self.raw, desired_version=desired_version, strict=strict
+        )
+
     def keys(self) -> list:
         """Return the keys of this object."""
         return self.raw.keys()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -785,3 +785,32 @@ async def test_secret_data(ns):
     await secret.create()
     assert "tls.crt" in secret.data
     await secret.delete()
+
+
+async def test_validate_pod(example_pod_spec):
+    pytest.importorskip("kubernetes_validate")
+    pod = await Pod(example_pod_spec)
+    await pod.validate("1.28", strict=True)
+
+
+async def test_validate_pod_fail():
+    kubernetes_validate = pytest.importorskip("kubernetes_validate")
+    pod = await Pod(
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "my-pod",
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name1": "pause",
+                        "image": "gcr.io/google_containers/pause",
+                    }
+                ]
+            },
+        }
+    )
+    with pytest.raises(kubernetes_validate.ValidationError):
+        await pod.validate("1.28", strict=True)

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -788,9 +788,9 @@ async def test_secret_data(ns):
 
 
 async def test_validate_pod(example_pod_spec):
-    pytest.importorskip("kubernetes_validate")
+    kubernetes_validate = pytest.importorskip("kubernetes_validate")
     pod = await Pod(example_pod_spec)
-    await pod.validate("1.28", strict=True)
+    kubernetes_validate.validate(pod.raw, "1.28", strict=True)
 
 
 async def test_validate_pod_fail():
@@ -813,4 +813,4 @@ async def test_validate_pod_fail():
         }
     )
     with pytest.raises(kubernetes_validate.ValidationError):
-        await pod.validate("1.28", strict=True)
+        kubernetes_validate.validate(pod.raw, "1.28", strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "kubernetes>=26.1.0",
     "pykube-ng>=23.6.0",
     "kubernetes-asyncio>=24.2.3",
+    "kubernetes-validate>=1.28.0",
 ]
 
 [tool.hatch.envs.test.scripts]


### PR DESCRIPTION
As discussed in https://github.com/kr8s-org/kr8s/issues/225#issuecomment-1838198368 `kr8s` will never add automatic client-side schema validation for objects. 

However, given that [`kubernetes-validate`](https://pypi.org/project/kubernetes-validate/) exists and is easy to use this PR adds an example to the documentation showing how to use it with `kr8s`.

```python
import kubernetes_validate
from kr8s.objects import Pod

pod = Pod({
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "name": "my-pod",
        },
        "spec": {
            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause",}]
        },
    })

kubernetes_validate.validate(pod.raw, "1.28")
pod.create()
```

> [!NOTE]  
> I've also opened https://github.com/willthames/kubernetes-validate/pull/23 which would enable passing objects directly to `kubernetes_validate.validate()` and means we could drop the `.raw` from the example (not just `kr8s` objects but `kubernetes`, `kubernetes_asyncio` and `lightkube` work with that change too).