### PR TITLE
Add ServerError exception

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -11,6 +11,7 @@ from ._exceptions import (
     ConnectionClosedError,  # noqa
     ExecError,  # noqa
     NotFoundError,  # noqa
+    ServerError,  # noqa
 )
 from ._io import run_sync as _run_sync
 from ._io import sync as _sync  # noqa

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -14,7 +14,7 @@ import httpx
 
 from ._auth import KubeAuth
 from ._data_utils import dict_to_selector
-from ._exceptions import APITimeoutError
+from ._exceptions import APITimeoutError, ServerError
 
 ALL = "all"
 
@@ -143,6 +143,11 @@ class Api(object):
                     await self._create_session()
                     continue
                 else:
+                    if e.response.status_code >= 400 and e.response.status_code < 500:
+                        error = e.response.json()
+                        raise ServerError(
+                            error["message"], status=error, response=e.response
+                        ) from e
                     raise
             except ssl.SSLCertVerificationError:
                 # In some rare edge cases the SSL verification fails, so we try again

--- a/kr8s/_exceptions.py
+++ b/kr8s/_exceptions.py
@@ -12,3 +12,20 @@ class APITimeoutError(Exception):
 
 class ExecError(Exception):
     """Internal error in the exec protocol."""
+
+
+class ServerError(Exception):
+    """Error from the Kubernetes API server.
+
+    Attributes
+    ----------
+    status : str
+        The Status object from the Kubernetes API server
+    response : httpx.Response
+        The httpx response object
+    """
+
+    def __init__(self, message, status=None, response=None):
+        self.status = status
+        self.response = response
+        super().__init__(message)

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -25,7 +25,7 @@ from kr8s._data_utils import (
     list_dict_unpack,
     xdict,
 )
-from kr8s._exceptions import NotFoundError
+from kr8s._exceptions import NotFoundError, ServerError
 from kr8s._exec import Exec
 from kr8s.asyncio.portforward import PortForward as AsyncPortForward
 from kr8s.portforward import PortForward as SyncPortForward
@@ -188,7 +188,7 @@ class APIObject:
                     resources = await api._get(
                         cls.endpoint, name, namespace=namespace, **kwargs
                     )
-                except httpx.HTTPStatusError as e:
+                except ServerError as e:
                     if e.response.status_code == 404:
                         continue
                     raise e
@@ -263,7 +263,7 @@ class APIObject:
                 data=json.dumps(data),
             ) as resp:
                 self.raw = resp.json()
-        except httpx.HTTPStatusError as e:
+        except ServerError as e:
             if e.response.status_code == 404:
                 raise NotFoundError(f"Object {self.name} does not exist") from e
             raise e
@@ -282,7 +282,7 @@ class APIObject:
                 namespace=self.namespace,
             ) as resp:
                 self.raw = resp.json()
-        except httpx.HTTPStatusError as e:
+        except ServerError as e:
             if e.response.status_code == 404:
                 raise NotFoundError(f"Object {self.name} does not exist") from e
             raise e
@@ -310,7 +310,7 @@ class APIObject:
                 headers=headers,
             ) as resp:
                 self.raw = resp.json()
-        except httpx.HTTPStatusError as e:
+        except ServerError as e:
             if e.response.status_code == 404:
                 raise NotFoundError(f"Object {self.name} does not exist") from e
             raise e

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -41,6 +41,27 @@ async def example_pod_spec(ns):
 
 
 @pytest.fixture
+async def bad_pod_spec(ns):
+    name = "example-" + uuid.uuid4().hex[:10]
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": name,
+            "namespace": ns,
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name1": "pause",  # This is bad
+                    "image": "gcr.io/google_containers/pause",
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture
 async def example_service_spec(ns):
     name = "example-" + uuid.uuid4().hex[:10]
     return {

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -4,7 +4,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-import httpx
 import pytest
 import yaml
 
@@ -104,7 +103,7 @@ async def test_bad_auth(serviceaccount):
         serviceaccount=serviceaccount, kubeconfig="/no/file/here"
     )
     serviceaccount = Path(serviceaccount)
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(kr8s.ServerError, match="Unauthorized"):
         await kubernetes.version()
 
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -793,24 +793,14 @@ async def test_validate_pod(example_pod_spec):
     kubernetes_validate.validate(pod.raw, "1.28", strict=True)
 
 
-async def test_validate_pod_fail():
+async def test_validate_pod_fail(bad_pod_spec):
     kubernetes_validate = pytest.importorskip("kubernetes_validate")
-    pod = await Pod(
-        {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {
-                "name": "my-pod",
-            },
-            "spec": {
-                "containers": [
-                    {
-                        "name1": "pause",
-                        "image": "gcr.io/google_containers/pause",
-                    }
-                ]
-            },
-        }
-    )
+    pod = await Pod(bad_pod_spec)
     with pytest.raises(kubernetes_validate.ValidationError):
         kubernetes_validate.validate(pod.raw, "1.28", strict=True)
+
+
+async def test_pod_errors(bad_pod_spec):
+    pod = await Pod(bad_pod_spec)
+    with pytest.raises(kr8s.ServerError, match="Required value"):
+        await pod.create()


### PR DESCRIPTION
Closes #118.

When we get an `httpx.HTTPStatusError` that we can't recover from there is usually a lot of information about what went wrong in the body of the response. This PR reraises that exception as a `kr8s.ServerError` which exposes the response status directly.

```python
>>> from kr8s.objects import Pod
>>> pod = Pod(invalid_pod_spec)
>>> pod.create()
ServerError: Pod "my-pod" is invalid: spec.containers[0].name: Required value
```

This is much more useful that the previous `HTTPStatusError: Client error '422 Unprocessable Entity' for url 'https://127.0.0.1:37237/api/v1/namespaces/default/pods'` exception.

The `ServerError` exception also has a `.status` attribute with the full server-side status object and a `.response` attribute with the `httpx.Response` object.