### PR TITLE
Warn on getting api-resources instead of failing

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import ssl
 import threading
+import warnings
 import weakref
 from typing import Dict, List, Tuple, Union
 
@@ -252,11 +253,14 @@ class Api(object):
         if watch:
             params["watch"] = "true" if watch else "false"
             kwargs["stream"] = True
-        resources = await self._api_resources()
-        for resource in resources:
-            if "shortNames" in resource and kind in resource["shortNames"]:
-                kind = resource["name"]
-                break
+        try:
+            resources = await self._api_resources()
+            for resource in resources:
+                if "shortNames" in resource and kind in resource["shortNames"]:
+                    kind = resource["name"]
+                    break
+        except ServerError as e:
+            warnings.warn(str(e))
         params = params or None
         obj_cls = get_class(kind, _asyncio=self._asyncio)
         async with self.call_api(

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -149,6 +149,10 @@ class Api(object):
                         raise ServerError(
                             error["message"], status=error, response=e.response
                         ) from e
+                    elif e.response.status_code >= 500:
+                        raise ServerError(
+                            str(e), status=e.response.status_code, response=e.response
+                        ) from e
                     raise
             except ssl.SSLCertVerificationError:
                 # In some rare edge cases the SSL verification fails, so we try again


### PR DESCRIPTION
This might close #230.

When we list resources we try and look up API resources in order to expand short names. However, if the API call to get the resource list fails we could still continue and just raise a warning instead of an exception. 

This means when the API call fails you can't use short names to look up resources, but you can still use full names.