### PR TITLE
Fix auth lookup order

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -57,10 +57,10 @@ class KubeAuth:
     async def reauthenticate(self) -> None:
         """Reauthenticate with the server."""
         async with self.__auth_lock:
-            if self._serviceaccount and not self.server:
-                await self._load_service_account()
             if self._kubeconfig is not False and not self.server:
                 await self._load_kubeconfig()
+            if self._serviceaccount and not self.server:
+                await self._load_service_account()
             if not self.server:
                 raise ValueError("Unable to find valid credentials")
 


### PR DESCRIPTION
The [documentation states](https://docs.kr8s.org/en/latest/authentication.html) that we load kubeconfig first and service account second, but then we don't actually do that.

This PR updates the order of the auth loading to match the documentation.

Closes #234