### PR TITLE
Add whoami API method

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,6 +24,15 @@ When reading from a kube config file the following authentication methods are su
 Support for the legacy `auth-provider` methods is not planned.
 ```
 
+````{tip}
+To find out which user `kr8s` is currently authenticated with you can call `client.whoami()`.
+
+```python
+>>> print(client.whoami())
+'kubernetes-admin'
+```
+````
+
 ## Manual configuration
 
 You can also manually specify authentication information when you create your kr8s client object.

--- a/kr8s/tests/resources/serviceaccount.yaml
+++ b/kr8s/tests/resources/serviceaccount.yaml
@@ -2,3 +2,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pytest
+---
+# Allow this service account to perform token reviews
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: pytest
+  namespace: default

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -65,6 +65,7 @@ async def test_kubeconfig(k8s_cluster):
     kubernetes = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
     version = await kubernetes.version()
     assert "major" in version
+    assert await kubernetes.whoami() == "kubernetes-admin"
 
 
 async def test_kubeconfig_context(kubeconfig_with_second_context):
@@ -140,5 +141,6 @@ async def test_exec(kubeconfig_with_exec):
 
 async def test_token(kubeconfig_with_token):
     kubernetes = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_token)
+    assert await kubernetes.whoami() == "system:serviceaccount:default:pytest"
     version = await kubernetes.version()
     assert "major" in version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "aiohttp>=3.8.4",
+    "cryptography>=35",
     "pyyaml>=6.0",
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",


### PR DESCRIPTION
Closes #236.

Look up the username that is currently authenticated. 

Implemented the same way as [`kubectl whoami`](https://github.com/rajatjindal/kubectl-whoami):

- If using a token we request a token review from the API and return the username provided.
- If using username/password we return the username.
- If using certificates we look at the username embedded in the client certificate.