### PR TITLE
Ensure tabs are synced in code examples

### DIFF
--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -7,6 +7,7 @@ Create a new {py:class}`Pod <kr8s.objects.Pod>`.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -26,6 +27,7 @@ pod.create()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -53,6 +55,7 @@ Create a new {py:class}`Pod <kr8s.objects.Pod>` and wait for it to be ready. The
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -70,6 +73,7 @@ while not pod.ready():
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -95,6 +99,7 @@ Create a {py:class}`Secret <kr8s.objects.Secret>` with several keys.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from base64 import b64encode
 from kr8s.objects import Secret
@@ -117,6 +122,7 @@ secret.create()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from base64 import b64encode
 from kr8s.asyncio.objects import Secret
@@ -151,6 +157,7 @@ Validate the schema of a {py:class}`Pod <kr8s.objects.Pod>` before creating it.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kubernetes_validate
 from kr8s.objects import Pod
@@ -172,6 +179,7 @@ pod.create()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kubernetes_validate
 from kr8s.asyncio.objects import Pod

--- a/docs/examples/generating_resources.md
+++ b/docs/examples/generating_resources.md
@@ -11,6 +11,7 @@ Generate a simple {py:class}`Pod <kr8s.objects.Pod>` with a couple of keyword ar
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -20,6 +21,7 @@ pod.create()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 

--- a/docs/examples/inspecting_resources.md
+++ b/docs/examples/inspecting_resources.md
@@ -7,6 +7,7 @@ Print out the logs from a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -17,6 +18,7 @@ for line in pod.logs():
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -36,6 +38,7 @@ Print out all the logs from a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -46,6 +49,7 @@ for line in pod.logs(follow=True, timeout=3600):
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 

--- a/docs/examples/labelling_operator.md
+++ b/docs/examples/labelling_operator.md
@@ -18,6 +18,7 @@ It then checks the {py:func}`Deployment.annotations <kr8s.objects.Deployment.ann
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 # controller.py
 import time
@@ -36,6 +37,7 @@ if __name__ == "__main__":
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 # controller.py
 import asyncio

--- a/docs/examples/listing_resources.md
+++ b/docs/examples/listing_resources.md
@@ -7,6 +7,7 @@ Print out all of the {py:class}`Node <kr8s.objects.Node>` names in the cluster u
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -16,6 +17,7 @@ for node in kr8s.get("nodes"):
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s.asyncio
 
@@ -33,6 +35,7 @@ List all Pods in all namespaces with {py:func}`kr8s.get()` and print their IP, n
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -42,6 +45,7 @@ for pod in kr8s.get("pods", namespace=kr8s.ALL):
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s
 
@@ -59,6 +63,7 @@ List all {py:class}`Ingresses <kr8s.objects.Ingress>` in the current namespace w
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -74,6 +79,7 @@ ings = kr8s.get("ingress.networking.k8s.io/v1")  # Full with explicit version al
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s.asyncio
 
@@ -96,6 +102,7 @@ Get a list of {py:class}`Pod <kr8s.objects.Pod>` resources that have the `Ready=
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -106,6 +113,7 @@ for pod in kr8s.get("pods", namespace="kube-system"):
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s
 
@@ -124,6 +132,7 @@ Starting from a dictionary containing a label selector get all {py:class}`Pods <
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -135,6 +144,7 @@ for pod in kr8s.get("pods", namespace=kr8s.ALL, label_selector=selector):
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s
 
@@ -154,6 +164,7 @@ Get a list of {py:class}`Pod <kr8s.objects.Pod>` resources that have `status.pha
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -163,6 +174,7 @@ for pod in kr8s.get("pods", namespace="kube-system", field_selector="status.phas
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s
 
@@ -180,6 +192,7 @@ List {py:class}`Pods <kr8s.objects.Pod>` with {py:func}`kr8s.get()` and sort the
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import kr8s
 
@@ -192,6 +205,7 @@ for pod in pods:
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import kr8s
 

--- a/docs/examples/modifying_resources.md
+++ b/docs/examples/modifying_resources.md
@@ -8,6 +8,7 @@ in the Namespace `kube-system` to `1` replica.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Deployment
 
@@ -17,6 +18,7 @@ deploy.scale(1)
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Deployment
 
@@ -34,6 +36,7 @@ Add the label `foo` with the value `bar` to an existing {py:class}`Pod <kr8s.obj
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -43,6 +46,7 @@ pod.label({"foo": "bar"})
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -60,6 +64,7 @@ Using the [JSON 6902](https://jsonpatch.com/) style patching replace all {py:cla
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -72,6 +77,7 @@ pod.patch(
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -92,6 +98,7 @@ Cordon a {py:class}`Node <kr8s.objects.Node>` to mark it as unschedulable with {
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Node
 
@@ -104,6 +111,7 @@ node.cordon()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Node
 

--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -7,6 +7,7 @@ Exec a command in a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.exec(
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -19,6 +20,7 @@ print(command.stdout.decode())
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -40,6 +42,7 @@ Run a command in a {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.exec()
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import sys
 from kr8s.objects import Pod
@@ -53,6 +56,7 @@ pod.exec(["ls", "/"], stdout=sys.stdout.buffer, stderr=sys.stderr.buffer, check=
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import sys
 from kr8s.asyncio.objects import Pod
@@ -74,6 +78,7 @@ Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 import requests
 from kr8s.objects import Pod
@@ -88,6 +93,7 @@ with pod.portforward(remote_port=1234) as local_port:
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 import httpx
 from kr8s.asyncio.objects import Pod
@@ -114,6 +120,7 @@ Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -123,6 +130,7 @@ pod.portforward(1234, local_port=5678).run_forever()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 
@@ -144,6 +152,7 @@ Open a port forward with {py:class}`Pod <kr8s.objects.Pod>` using {py:func}`Pod.
 `````{tab-set}
 
 ````{tab-item} Sync
+:sync: sync
 ```python
 from kr8s.objects import Pod
 
@@ -161,6 +170,7 @@ pf.stop()
 ````
 
 ````{tab-item} Async
+:sync: async
 ```python
 from kr8s.asyncio.objects import Pod
 


### PR DESCRIPTION
Set the `:sync:` property on the `sphinx-design` tabs so that when you toggle between sync and asyncio examples all fo the code examples change.

This avoids the frustration of trying to read many asyncio examples and having to click on all of them.

![Screen Recording 2023-12-12 at 14 20 13 (1)](https://github.com/kr8s-org/kr8s/assets/1610850/19a89ec1-0d28-4c38-a687-7f379c1290cd)
