### PR TITLE
Add .list() method to objects and allow passing APIObjects to kr8s.get()

### DIFF
--- a/docs/examples/listing_resources.md
+++ b/docs/examples/listing_resources.md
@@ -66,6 +66,7 @@ List all {py:class}`Ingresses <kr8s.objects.Ingress>` in the current namespace w
 :sync: sync
 ```python
 import kr8s
+from kr8s.objects import Ingress
 
 # All of these are equivalent
 ings = kr8s.get("ing")                           # Short name
@@ -75,6 +76,7 @@ ings = kr8s.get("Ingress")                       # Title
 ings = kr8s.get("ingress.networking.k8s.io")     # Full group name
 ings = kr8s.get("ingress.v1.networking.k8s.io")  # Full with explicit version
 ings = kr8s.get("ingress.networking.k8s.io/v1")  # Full with explicit version alt.
+ings = kr8s.get(Ingress)                         # Class
 ```
 ````
 
@@ -82,6 +84,7 @@ ings = kr8s.get("ingress.networking.k8s.io/v1")  # Full with explicit version al
 :sync: async
 ```python
 import kr8s.asyncio
+from kr8s.asyncio.objects import Ingress
 
 # All of these are equivalent
 ings = await kr8s.asyncio.get("ing")                           # Short name
@@ -91,6 +94,7 @@ ings = await kr8s.asyncio.get("Ingress")                       # Title
 ings = await kr8s.asyncio.get("ingress.networking.k8s.io")     # Full group name
 ings = await kr8s.asyncio.get("ingress.v1.networking.k8s.io")  # Full with explicit version
 ings = await kr8s.asyncio.get("ingress.networking.k8s.io/v1")  # Full with explicit version alt.
+ings = await kr8s.asyncio.get(Ingress)                         # Class
 ```
 ````
 

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -350,6 +350,19 @@ class APIObject:
         async for event, obj in self._watch():
             yield event, obj
 
+    @classmethod
+    async def list(cls, **kwargs) -> List[APIObjectType]:
+        """List objects in Kubernetes.
+
+        Args:
+            **kwargs: Keyword arguments to pass to :func:`kr8s.get`.
+
+        Returns:
+            A list of objects.
+        """
+        api = await kr8s.asyncio.api()
+        return await api._get(kind=cls, **kwargs)
+
     async def _test_conditions(self, conditions: list) -> bool:
         """Test if conditions are met."""
         for condition in conditions:

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -183,7 +183,7 @@ async def test_get_deployments():
 
 async def test_get_class():
     api = await kr8s.asyncio.api()
-    pods = await api.get(Pod)
+    pods = await api.get(Pod, namespace=kr8s.ALL)
     assert isinstance(pods, list)
     assert len(pods) > 0
     assert isinstance(pods[0], Pod)

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -181,6 +181,14 @@ async def test_get_deployments():
     assert isinstance(deployments, list)
 
 
+async def test_get_class():
+    api = await kr8s.asyncio.api()
+    pods = await api.get(Pod)
+    assert isinstance(pods, list)
+    assert len(pods) > 0
+    assert isinstance(pods[0], Pod)
+
+
 async def test_api_resources():
     resources = await kr8s.asyncio.api_resources()
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -800,3 +800,13 @@ async def test_pod_errors(bad_pod_spec):
     pod = await Pod(bad_pod_spec)
     with pytest.raises(kr8s.ServerError, match="Required value"):
         await pod.create()
+
+
+async def test_pod_list():
+    pods1 = await kr8s.asyncio.get("pods", namespace=kr8s.ALL)
+    pods2 = await Pod.list(namespace=kr8s.ALL)
+    assert pods1 and pods2
+    assert len(pods1) == len(pods2)
+    assert all(isinstance(p, Pod) for p in pods1)
+    assert all(isinstance(p, Pod) for p in pods2)
+    assert {p.name for p in pods1} == {p.name for p in pods2}


### PR DESCRIPTION
Closes #249 

To enable listing resources with a little stronger typing this PR implements an `APIObject.list()` method.

```python
from kr8s.objects import Pod

pods = Pod.list()
```

Under the hood this calls `kr8s.get(Pod)` (or the asyncio equivalent) so the second thing this PR does is update `kr8s.get()` and `kr8s.asyncio.get()` to accept types in addition to strings for the resource kind.

```python
import kr8s
from kr8s.objects import Pod

pods = kr8s.get(Pod)
```