### PR TITLE
Avoid looking up API resources on APIObject.get() calls

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -193,16 +193,14 @@ class APIObject:
         while start + timeout > time.time():
             if name:
                 try:
-                    resources = await api._get(
-                        cls.endpoint, name, namespace=namespace, **kwargs
-                    )
+                    resources = await api._get(cls, name, namespace=namespace, **kwargs)
                 except ServerError as e:
                     if e.response.status_code == 404:
                         continue
                     raise e
             elif label_selector or field_selector:
                 resources = await api._get(
-                    cls.endpoint,
+                    cls,
                     namespace=namespace,
                     label_selector=label_selector,
                     field_selector=field_selector,


### PR DESCRIPTION
Now that #249 has implemented the ability to pass objects to `kr8s.get()` we can pass the `cls` in places like the `APIObject.get()` classmethod instead of passing the endpoint name.

One benefit of this is that we don't need to look up API resources to resolve the string back into a class again. This closes #251.