### PR TITLE
Add caching to API Resources

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Tuple, Union
 
 import aiohttp
 import httpx
+from asyncache import cached
+from cachetools import TTLCache
 from cryptography import x509
 
 from ._auth import KubeAuth
@@ -443,6 +445,9 @@ class Api(object):
         """Get the Kubernetes API resources."""
         return await self._api_resources()
 
+    # Cache for 10 minutes because kubectl does
+    # https://github.com/kubernetes/kubernetes/blob/0fb71846df9babb6012a7fce22e2533e9d795baa/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L253
+    @cached(TTLCache(1, 600))
     async def _api_resources(self) -> dict:
         """Get the Kubernetes API resources."""
         resources = []

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -14,6 +14,8 @@ def test_trio_runs():
         api = await kr8s.asyncio.api()
         version = await api.version()
         assert "major" in version
+        api_resources = await api.api_resources()
+        assert api_resources
 
     trio.run(main)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
     "aiohttp>=3.8.4",
+    "asyncache>=0.3.1",
     "cryptography>=35",
     "pyyaml>=6.0",
     "python-jsonpath>=0.7.1",


### PR DESCRIPTION
Closes #253 
Xref #251

Calling `kr8s.api_resources()` can be [an expensive operation](https://jonnylangefeld.com/blog/the-kubernetes-discovery-cache-blessing-and-curse), and `kr8s.get()` calls this under the hood every time. So this PR adds a cache to that call.

It looks like `kubectl` [caches these requests to a file on disk for 10 minutes](https://github.com/kubernetes/kubernetes/blob/0fb71846df9babb6012a7fce22e2533e9d795baa/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L253), which makes sense given that `kubectl` can't maintain an in-memory cache between separate CLI calls. I considered trying to reuse the cache that `kubectl` uses, but I feel that ties us too closely to a `kubectl` implementation detail.