### PR TITLE
Cache api-resources for longer

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -447,7 +447,7 @@ class Api(object):
 
     # Cache for 6 hours because kubectl does
     # https://github.com/kubernetes/cli-runtime/blob/980bedf450ab21617b33d68331786942227fe93a/pkg/genericclioptions/config_flags.go#L297
-    @cached(TTLCache(1, 600))
+    @cached(TTLCache(1, 60 * 60 * 6))
     async def _api_resources(self) -> dict:
         """Get the Kubernetes API resources."""
         resources = []

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -445,8 +445,8 @@ class Api(object):
         """Get the Kubernetes API resources."""
         return await self._api_resources()
 
-    # Cache for 10 minutes because kubectl does
-    # https://github.com/kubernetes/kubernetes/blob/0fb71846df9babb6012a7fce22e2533e9d795baa/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go#L253
+    # Cache for 6 hours because kubectl does
+    # https://github.com/kubernetes/cli-runtime/blob/980bedf450ab21617b33d68331786942227fe93a/pkg/genericclioptions/config_flags.go#L297
     @cached(TTLCache(1, 600))
     async def _api_resources(self) -> dict:
         """Get the Kubernetes API resources."""


### PR DESCRIPTION
Follow on from #254. It looks like in https://github.com/kubernetes/kubernetes/pull/107141 the `kubectl` cache time was increased to 6 hours.