### PR TITLE
Suppress connection closed exceptions in port forwards

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         kubernetes-version: ["1.29.0"]
         include:
           - python-version: '3.10'

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -19,8 +19,8 @@ from ._exceptions import ConnectionClosedError
 if TYPE_CHECKING:
     from .objects import APIObject
 
-if sys.version_info > (3, 12):
-    # contextlib.supress() in Python 3.12 supprts ExceptionGroups
+if sys.version_info < (3, 12, 1):
+    # contextlib.supress() in Python 3.12.1 supprts ExceptionGroups
     # For older versions, we use the exceptiongroup backport
     from exceptiongroup import suppress  # noqa: F811
 

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -19,7 +19,7 @@ from ._exceptions import ConnectionClosedError
 if TYPE_CHECKING:
     from .objects import APIObject
 
-if sys.version_info >= (3, 12):
+if sys.version_info > (3, 12):
     # contextlib.supress() in Python 3.12 supprts ExceptionGroups
     # For older versions, we use the exceptiongroup backport
     from exceptiongroup import suppress  # noqa: F811

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import random
 import socket
+import sys
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING, BinaryIO
 
@@ -17,6 +18,11 @@ from ._exceptions import ConnectionClosedError
 
 if TYPE_CHECKING:
     from .objects import APIObject
+
+if sys.version_info >= (3, 12):
+    # contextlib.supress() in Python 3.12 supprts ExceptionGroups
+    # For older versions, we use the exceptiongroup backport
+    from exceptiongroup import suppress  # noqa: F811
 
 
 class PortForward:
@@ -183,11 +189,10 @@ class PortForward:
         """Start two tasks to copy bytes from tcp=>websocket and websocket=>tcp."""
         try:
             async with self._connect_websocket() as ws:
-                async with anyio.create_task_group() as tg:
-                    tg.start_soon(self._tcp_to_ws, ws, reader)
-                    tg.start_soon(self._ws_to_tcp, ws, writer)
-        except ConnectionClosedError:
-            pass
+                with suppress(ConnectionClosedError):
+                    async with anyio.create_task_group() as tg:
+                        tg.start_soon(self._tcp_to_ws, ws, reader)
+                        tg.start_soon(self._ws_to_tcp, ws, writer)
         finally:
             writer.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "aiohttp>=3.8.4",
     "asyncache>=0.3.1",
     "cryptography>=35",
+    "exceptiongroup >= 1.2.0; python_version < '3.12'",
     "pyyaml>=6.0",
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",


### PR DESCRIPTION
Closes #223 

Since migrating the port forwarding code to use `anyio` if you're using Python >=3.11 an `ExceptionGroup` is raised when the tasks in a `taskgroup` raises. This breaks the `try: ... except ConnectionClosedError: pass` we have to handle when sockets closing which results in an annoying warning as covered in #223.

It looks like in Python 3.12.1 `contextlib.suppress()` from the standard library can handle `ExceptionGroups` but for 3.11 we need to use the backport provided in the `exceptiongroup` package.

It also looks like `anyio` depends on `exceptiongroup` [only up until Python 3.10](https://github.com/agronholm/anyio/blob/f757314f8925682311e768bc586ec41e046e0f36/pyproject.toml#L30) but we need this shim in 3.11, so I am updating our dependencies to include it up until 3.11.

Given we are touching on Python 3.12 features this seems like a good time to add 3.12 to our CI matrix too.