### PR TITLE
Add contributing docs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,8 +4,57 @@ Contributions are very welcome. Check out our [open issues on GitHub](https://gi
 
 ## Development environment
 
-TODO
+We recommend you develop `kr8s` inside a virtual environment. We use [hatch](https://hatch.pypa.io/) for builds, virtual environments and task running, but you can use whatever you prefer.
+
+```bash
+pip install hatch
+hatch shell  # Creates the hatch venv and activates it
+```
+
+But there are many different tools out there so feel free to use whichever you prefer and install `kr8s` in development mode.
+
+```bash
+# Create/activate your Python environment
+pip install -e .
+```
 
 ## Testing
 
-TODO
+Tests in `kr8s` are run with `pytest`. To handle testing again Kubernetes we also use [kind](https://kind.sigs.k8s.io/) via the [`pytest-kind`](https://pypi.org/project/pytest-kind/) plugin. Kind launches a Kubernetes cluster inside a single Docker container which is great for local development. All setup is handles via fixtures so as long as you have `docker` you can run the tests.
+
+```bash
+hatch run test:run
+```
+
+Or you can install the test dependencies and invoke `pytest` yourself.
+
+```bash
+pip install -e .[test]
+pytest kr8s
+```
+
+## Documentation
+
+Documentation is built with [Sphinx](https://www.sphinx-doc.org/en/master/). You can build the docs locally.
+
+```bash
+hatch run docs:serve
+```
+
+Or you can install the docs dependencies and invoke `sphinx-build` or `sphinx-autobuild` yourself.
+
+```bash
+pip install -e .[docs]
+sphinx-autobuild docs docs/_build --ignore 'docs/autoapi/**/*' --host 0.0.0.0
+```
+
+## Linting
+
+We lint `kr8s` with `black` and `ruff`. We recommend you install [`pre-commit`](https://pre-commit.com/) to do this on each commit.
+
+```console
+$ pip install pre-commit
+$ pre-commit install
+$ # You can manually run pre-commit on all files too
+$ pre-commit run --all
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,8 @@ dependencies = [
     "httpx>=0.24.1",
     "python-box>=7.0.1",
 ]
-
-[tool.pytest.ini_options]
-addopts = "-v --keep-cluster --durations=10 --cov=kr8s --cov-report term-missing --cov-report xml:coverage.xml"
-timeout = 300
-xfail_strict = true
-reruns = 3
-reruns_delay = 1
-asyncio_mode = "auto"
-
-[tool.hatch.envs.test]
-dependencies = [
+[project.optional-dependencies]
+test = [
     "pytest>=7.2.2",
     "pytest-asyncio>=0.20.3",
     "pytest-kind@git+https://codeberg.org/hjacobs/pytest-kind.git",
@@ -43,12 +34,7 @@ dependencies = [
     "kubernetes-asyncio>=24.2.3",
     "kubernetes-validate>=1.28.0",
 ]
-
-[tool.hatch.envs.test.scripts]
-run = "pytest kr8s"
-
-[tool.hatch.envs.docs]
-dependencies = [
+docs = [
     "sphinx>=5.3.0",
     "sphinx-autobuild>=2021.3.14",
     "myst-parser>=1.0.0",
@@ -58,6 +44,24 @@ dependencies = [
     "sphinxcontrib-mermaid>=0.8.1",
     "sphinx-autoapi>=2.1.0",
 ]
+
+[tool.pytest.ini_options]
+addopts = "-v --keep-cluster --durations=10 --cov=kr8s --cov-report term-missing --cov-report xml:coverage.xml"
+timeout = 300
+xfail_strict = true
+reruns = 3
+reruns_delay = 1
+asyncio_mode = "auto"
+
+[tool.hatch.envs.test]
+features = ["test"]
+
+[tool.hatch.envs.test.scripts]
+default = "pytest kr8s"
+run = "pytest kr8s"
+
+[tool.hatch.envs.docs]
+features = ["docs"]
 
 [tool.hatch.envs.docs.scripts]
 build = "sphinx-build docs/ docs/_build/"


### PR DESCRIPTION
Start adding contributing docs. First step is to make it easy to develop without hatch for folks who already have a preferred workflow.