### PR TITLE
Rework exec to explicitly use the v4.channel.k8s.io protocol and add support for future v5

### DIFF
--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -759,7 +759,7 @@ async def test_pod_exec_to_file(ubuntu_pod):
         assert b"invalid date" in tmp.read()
 
 
-@pytest.mark.skip("Closing stdin not supported so hangs forever")
+@pytest.mark.xfail(reason="Exec protocol v5.channel.k8s.io not available")
 async def test_pod_exec_stdin(ubuntu_pod):
     ex = await ubuntu_pod.exec(["cat"], stdin="foo")
     assert b"foo" in ex.stdout


### PR DESCRIPTION
Rework the exec to explicitly use the v4.channel.k8s.io protocol which gives richer status messages and also raises an exception when using stdin instead of hanging.

This also adds support for the v5 protocol and handles closing the stdin stream (xref #212), but this support is currently disabled while I explore auto-detecting if the protocol is supported before enabling it.