### PR TITLE
Enable reading certs from files

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -157,7 +157,9 @@ class KubeAuth:
             if await client_key_path.exists():
                 self.client_key_file = self._user["client-key"]
             else:
-                self.client_key_file = anyio.Path(self._kubeconfig) / client_key_path
+                self.client_key_file = (
+                    anyio.Path(self._kubeconfig).parent / client_key_path
+                )
         if "client-key-data" in self._user:
             async with NamedTemporaryFile(delete=False) as key_file:
                 await key_file.write_bytes(
@@ -169,7 +171,9 @@ class KubeAuth:
             if await client_key_path.exists():
                 self.client_cert_file = self._user["client-certificate"]
             else:
-                self.client_cert_file = anyio.Path(self._kubeconfig) / client_cert_path
+                self.client_cert_file = (
+                    anyio.Path(self._kubeconfig).parent / client_cert_path
+                )
         if "client-certificate-data" in self._user:
             async with NamedTemporaryFile(delete=False) as cert_file:
                 await cert_file.write_bytes(
@@ -181,7 +185,9 @@ class KubeAuth:
             if await client_key_path.exists():
                 self.server_ca_file = self._user["certificate-authority"]
             else:
-                self.server_ca_file = anyio.Path(self._kubeconfig) / server_ca_path
+                self.server_ca_file = (
+                    anyio.Path(self._kubeconfig).parent / server_ca_path
+                )
         if "certificate-authority-data" in self._cluster:
             async with NamedTemporaryFile(delete=False) as ca_file:
                 await ca_file.write_bytes(

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -188,14 +188,6 @@ class KubeAuth:
                     base64.b64decode(self._cluster["certificate-authority-data"])
                 )
                 self.server_ca_file = str(ca_file)
-        if "certificate-authority" in self._cluster:
-            if os.path.isfile(self._cluster["certificate-authority"]):
-                self.server_ca_file = self._cluster["certificate-authority"]
-            else:
-                self.server_ca_file = os.path.join(
-                    os.path.dirname(self._kubeconfig),
-                    self._cluster["certificate-authority"],
-                )
         if "token" in self._user:
             self.token = self._user["token"]
         if "username" in self._user or "password" in self._user:

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -152,18 +152,36 @@ class KubeAuth:
             else:
                 raise KeyError(f"Did not find credentials in {command} output.")
 
+        if "client-key" in self._user:
+            client_key_path = anyio.Path(self._user["client-key"])
+            if await client_key_path.exists():
+                self.client_key_file = self._user["client-key"]
+            else:
+                self.client_key_file = anyio.Path(self._kubeconfig) / client_key_path
         if "client-key-data" in self._user:
             async with NamedTemporaryFile(delete=False) as key_file:
                 await key_file.write_bytes(
                     base64.b64decode(self._user["client-key-data"])
                 )
                 self.client_key_file = str(key_file)
+        if "client-certificate" in self._user:
+            client_cert_path = anyio.Path(self._user["client-certificate"])
+            if await client_key_path.exists():
+                self.client_cert_file = self._user["client-certificate"]
+            else:
+                self.client_cert_file = anyio.Path(self._kubeconfig) / client_cert_path
         if "client-certificate-data" in self._user:
             async with NamedTemporaryFile(delete=False) as cert_file:
                 await cert_file.write_bytes(
                     base64.b64decode(self._user["client-certificate-data"])
                 )
                 self.client_cert_file = str(cert_file)
+        if "certificate-authority" in self._user:
+            server_ca_path = anyio.Path(self._user["certificate-authority"])
+            if await client_key_path.exists():
+                self.server_ca_file = self._user["certificate-authority"]
+            else:
+                self.server_ca_file = anyio.Path(self._kubeconfig) / server_ca_path
         if "certificate-authority-data" in self._cluster:
             async with NamedTemporaryFile(delete=False) as ca_file:
                 await ca_file.write_bytes(

--- a/kr8s/tests/resources/serviceaccount.yaml
+++ b/kr8s/tests/resources/serviceaccount.yaml
@@ -17,3 +17,27 @@ subjects:
 - kind: ServiceAccount
   name: pytest
   namespace: default
+---
+# Allow this service account to list pods
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pytest-list-pods
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pytest-list-pods-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pytest-list-pods
+subjects:
+- kind: ServiceAccount
+  name: pytest
+  namespace: default


### PR DESCRIPTION
Closes #263 

- Adds support for kubeconfigs with `client-certificate` and `client-key` specified as a path.
  - Updated the existing `certificate-authority` support to use `anyio.Path`.
- Added a test to set up this scenario by writing the kind cert data to disk and generating a temporary kubeconfig with the paths.
- Updated all auth tests to try and list pods instead of checking versions because the current tests will succeed as an anonymous user.
  - Needed to add some RBAC config for the token test to allow listing pods.