### PR TITLE
Implement Custom Bind Address for Port Forwarding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 #  dependency. Make sure to update flake8-bugbear manually on a regular basis.
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
         language_version: python3
@@ -11,7 +11,7 @@ repos:
           - --target-version=py38
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.1.8'
+    rev: 'v0.1.9'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/docs/examples/pod_operations.md
+++ b/docs/examples/pod_operations.md
@@ -89,6 +89,19 @@ with pod.portforward(remote_port=1234) as local_port:
     # Make an API request
     resp = requests.get(f"http://localhost:{local_port}")
     # Do something with the response
+
+# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+with pod.portforward(remote_port=5000, local_port=8888, address=["0.0.0.0"])
+    # Make an API request
+    resp = requests.get(f"http://0.0.0.0:{local_port}")
+    # Do something with the response
+  
+# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+pf = pod.portforward(port=5000, local_port=8888, address=["127.0.0.1", "10.19.21.1"])
+    # Make an API request
+    resp = requests.get(f"http://10.19.21.1:{local_port}")
+    # Do something with the response
+    
 ```
 ````
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -302,11 +302,6 @@ pod = Pod.get("my-pod")
 # Listen on port 5678 on 127.0.0.1, forwarding to 5000 in the pod
 pf = pod.portforward(remote_port=5000, local_port=5678)
 
-# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
-pf = pod.portforward(remote_port=5000, local_port=8888, address=["0.0.0.0"])
-  
-# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
-pf = pod.portforward(port=5000, local_port=8888, address=["127.0.0.1", "10.19.21.23"])
 
 # Starts the port forward in a background thread
 pf.start()

--- a/docs/index.md
+++ b/docs/index.md
@@ -299,7 +299,14 @@ Open a port forward to a Pod as a background task/thread.
 from kr8s.objects import Pod
 
 pod = Pod.get("my-pod")
-pf = pod.portforward(remote_port=1234, local_port=5678)
+# Listen on port 5678 on 127.0.0.1, forwarding to 5000 in the pod
+pf = pod.portforward(remote_port=5000, local_port=5678)
+
+# Listen on port 8888 on all addresses, forwarding to 5000 in the pod
+pf = pod.portforward(remote_port=5000, local_port=8888, address=["0.0.0.0"])
+  
+# Listen on port 8888 on localhost and selected IP, forwarding to 5000 in the pod
+pf = pod.portforward(port=5000, local_port=8888, address=["127.0.0.1", "10.19.21.23"])
 
 # Starts the port forward in a background thread
 pf.start()

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -810,9 +810,7 @@ class Pod(APIObject):
                 async for line in resp.aiter_lines():
                     yield line
 
-    def portforward(
-        self, remote_port: int, local_port: int = None, address: List[str] = ["127.0.0.1"]
-    ) -> int:
+    def portforward(self, remote_port: int, local_port: int = None, address: List[str] | str = "127.0.0.1" ) -> int:
         """Port forward a pod.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Pod.
@@ -834,7 +832,16 @@ class Pod(APIObject):
             >>> print(f"Forwarding to port {pf.local_port}")
             >>> # Do something with port 8888
             >>> await pf.stop()
-        """
+
+            Explict bind address:
+            
+            >>> async with pod.PortForward(8888, address=["127.0.0.1", "10.20.0.1"]) as port:
+            ...     print(f"Forwarding to port {port}")
+            ...     # Do something with port 8888 on the Pod, port will be bind to 127.0.0.1 and 10.20.0.1
+
+            """
+        if isinstance(address, str):
+            address = [address]
         if self._asyncio:
             return AsyncPortForward(self, remote_port, local_port, address)
         return SyncPortForward(self, remote_port, local_port, address)
@@ -1135,7 +1142,7 @@ class Service(APIObject):
         pods = await self._ready_pods()
         return len(pods) > 0
 
-    def portforward(self, remote_port: int, local_port: int = None, address: List[str] = ["127.0.0.1"]) -> int:
+    def portforward(self, remote_port: int, local_port: int = None, address: str | List[str] = "127.0.0.1") -> int:
         """Port forward a service.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Service.
@@ -1159,9 +1166,11 @@ class Service(APIObject):
             >>> await pf.stop()
 
         """
+        if isinstance(address, str):
+            address = [address]
         if self._asyncio:
-            return AsyncPortForward(self, remote_port, local_port)
-        return SyncPortForward(self, remote_port, local_port)
+            return AsyncPortForward(self, remote_port, local_port, address)
+        return SyncPortForward(self, remote_port, local_port, address)
 
 
 ## apps/v1 objects

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -810,7 +810,7 @@ class Pod(APIObject):
                 async for line in resp.aiter_lines():
                     yield line
 
-    def portforward(self, remote_port: int, local_port: int = None) -> int:
+    def portforward(self, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0" ) -> int:
         """Port forward a pod.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Pod.
@@ -834,8 +834,8 @@ class Pod(APIObject):
             >>> await pf.stop()
         """
         if self._asyncio:
-            return AsyncPortForward(self, remote_port, local_port)
-        return SyncPortForward(self, remote_port, local_port)
+            return AsyncPortForward(self, remote_port, local_port, bind_address)
+        return SyncPortForward(self, remote_port, local_port, bind_address)
 
     async def _exec(
         self,

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -810,7 +810,9 @@ class Pod(APIObject):
                 async for line in resp.aiter_lines():
                     yield line
 
-    def portforward(self, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0" ) -> int:
+    def portforward(
+        self, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0"
+    ) -> int:
         """Port forward a pod.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Pod.

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -811,7 +811,7 @@ class Pod(APIObject):
                     yield line
 
     def portforward(
-        self, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0"
+        self, remote_port: int, local_port: int = None, address: List[str] = ["127.0.0.1"]
     ) -> int:
         """Port forward a pod.
 
@@ -836,8 +836,8 @@ class Pod(APIObject):
             >>> await pf.stop()
         """
         if self._asyncio:
-            return AsyncPortForward(self, remote_port, local_port, bind_address)
-        return SyncPortForward(self, remote_port, local_port, bind_address)
+            return AsyncPortForward(self, remote_port, local_port, address)
+        return SyncPortForward(self, remote_port, local_port, address)
 
     async def _exec(
         self,
@@ -1135,7 +1135,7 @@ class Service(APIObject):
         pods = await self._ready_pods()
         return len(pods) > 0
 
-    def portforward(self, remote_port: int, local_port: int = None) -> int:
+    def portforward(self, remote_port: int, local_port: int = None, address: List[str] = ["127.0.0.1"]) -> int:
         """Port forward a service.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Service.

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -810,7 +810,12 @@ class Pod(APIObject):
                 async for line in resp.aiter_lines():
                     yield line
 
-    def portforward(self, remote_port: int, local_port: int = None, address: List[str] | str = "127.0.0.1" ) -> int:
+    def portforward(
+        self,
+        remote_port: int,
+        local_port: int = None,
+        address: List[str] | str = "127.0.0.1",
+    ) -> int:
         """Port forward a pod.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Pod.
@@ -834,12 +839,12 @@ class Pod(APIObject):
             >>> await pf.stop()
 
             Explict bind address:
-            
+
             >>> async with pod.PortForward(8888, address=["127.0.0.1", "10.20.0.1"]) as port:
             ...     print(f"Forwarding to port {port}")
             ...     # Do something with port 8888 on the Pod, port will be bind to 127.0.0.1 and 10.20.0.1
 
-            """
+        """
         if isinstance(address, str):
             address = [address]
         if self._asyncio:
@@ -1142,8 +1147,12 @@ class Service(APIObject):
         pods = await self._ready_pods()
         return len(pods) > 0
 
-    def portforward(self, remote_port: int, local_port: int = None, address: str | List[str] = "127.0.0.1") -> int:
-
+    def portforward(
+        self,
+        remote_port: int,
+        local_port: int = None,
+        address: str | List[str] = "127.0.0.1",
+    ) -> int:
         """Port forward a service.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Service.

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -166,7 +166,6 @@ class PortForward:
                 await server.start_serving()
             yield self.local_port
 
-
         finally:
             # Ensure all servers are closed properly
             for server in self.servers:

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -66,7 +66,11 @@ class PortForward:
     """
 
     def __init__(
-        self, resource: APIObject, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0" 
+        self,
+        resource: APIObject,
+        remote_port: int,
+        local_port: int = None,
+        bind_address: str = "0.0.0.0",
     ) -> None:
         with suppress(sniffio.AsyncLibraryNotFoundError):
             if sniffio.current_async_library() != "asyncio":

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -165,9 +165,7 @@ class PortForward:
             for server in self.servers:
                 async with server:
                     await server.start_serving()
-                    for sock in server.sockets:
-                        if sock.family == socket.AF_INET:
-                            yield sock.getsockname()[1]
+            yield self.local_port
         finally:
             # Ensure all servers are closed properly
             self.servers[0].close()

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -273,11 +273,9 @@ class PortForward:
         """
         Find a random port that is not in use on any of the given addresses.
 
-        :param address_list: List of addresses to check the port against.
         :return: An available port number.
         """
         while True:
             port = random.randint(10000, 60000)
-            print(port)
             if not any(self._is_port_in_use(port, address) for address in self.address):
                 return port

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -163,15 +163,15 @@ class PortForward:
 
         try:
             for server in self.servers:
-                async with server:
-                    await server.start_serving()
-                    yield self.local_port
+                await server.start_serving()
+            yield self.local_port
+
 
         finally:
             # Ensure all servers are closed properly
-            self.servers[0].close()
-            await self.servers[0].wait_closed()
             for server in self.servers:
+                server.close()
+                await server.wait_closed()
                 self.servers.remove(server)
 
     async def _select_pod(self) -> object:

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -73,9 +73,12 @@ class PortForward:
     """
 
     def __init__(
-        self, resource: APIObject, remote_port: int, local_port: int = None, address: List[str] | str = "127.0.0.1"
+        self,
+        resource: APIObject,
+        remote_port: int,
+        local_port: int = None,
+        address: List[str] | str = "127.0.0.1",
     ) -> None:
-
         with suppress(sniffio.AsyncLibraryNotFoundError):
             if sniffio.current_async_library() != "asyncio":
                 raise RuntimeError(
@@ -151,7 +154,7 @@ class PortForward:
         if self.local_port == 0:
             self.local_port = self._find_available_port()
 
-        for address in self.address: 
+        for address in self.address:
             server = await asyncio.start_server(
                 self._sync_sockets, port=self.local_port, host=address
             )
@@ -166,10 +169,10 @@ class PortForward:
                             yield sock.getsockname()[1]
         finally:
             # Ensure all servers are closed properly
-                self.servers[0].close()
-                await self.servers[0].wait_closed()
-                for server in self.servers:
-                    self.servers.remove(server)
+            self.servers[0].close()
+            await self.servers[0].wait_closed()
+            for server in self.servers:
+                self.servers.remove(server)
 
     async def _select_pod(self) -> object:
         """Select a Pod to forward to."""
@@ -254,7 +257,7 @@ class PortForward:
                     writer.write(message.data[1:])
                     await writer.drain()
 
-    def _is_port_in_use(self, port: int, host: str = '127.0.0.1'):
+    def _is_port_in_use(self, port: int, host: str = "127.0.0.1"):
         """
         Check if a given port is in use on a specified host.
 
@@ -264,7 +267,6 @@ class PortForward:
         """
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             return s.connect_ex((host, port)) == 0
-
 
     def _find_available_port(self):
         """

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -165,7 +165,8 @@ class PortForward:
             for server in self.servers:
                 async with server:
                     await server.start_serving()
-            yield self.local_port
+                    yield self.local_port
+
         finally:
             # Ensure all servers are closed properly
             self.servers[0].close()

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -8,7 +8,7 @@ import random
 import socket
 import sys
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, BinaryIO, List
 
 import aiohttp
 import anyio
@@ -44,7 +44,8 @@ class PortForward:
 
         ``local_port`` (int, optional): The local port to listen on. Defaults to 0, which will choose a random port.
 
-        ``address``(List[str] | str, optional): List of addresses or address to listen on. Defaults to ["127.0.0.1"], will listen only on 127.0.0.1
+        ``address``(List[str] | str, optional): List of addresses or address to listen on. Defaults to ["127.0.0.1"],
+         will listen only on 127.0.0.1
 
     Example:
         This class can be used as a an async context manager or with explicit start/stop methods.

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -66,7 +66,7 @@ class PortForward:
     """
 
     def __init__(
-        self, resource: APIObject, remote_port: int, local_port: int = None
+        self, resource: APIObject, remote_port: int, local_port: int = None, bind_address: str = "0.0.0.0" 
     ) -> None:
         with suppress(sniffio.AsyncLibraryNotFoundError):
             if sniffio.current_async_library() != "asyncio":
@@ -77,6 +77,7 @@ class PortForward:
         self.server = None
         self.remote_port = remote_port
         self.local_port = local_port if local_port is not None else 0
+        self.bind_address = bind_address
         from ._objects import Pod
 
         if not isinstance(resource, Pod) and not hasattr(resource, "ready_pods"):
@@ -136,7 +137,7 @@ class PortForward:
     async def _run(self) -> int:
         """Start the port forward and yield the local port."""
         self.server = await asyncio.start_server(
-            self._sync_sockets, port=self.local_port, host="0.0.0.0"
+            self._sync_sockets, port=self.local_port, host=self.bind_address
         )
         async with self.server:
             await self.server.start_serving()

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -17,6 +17,8 @@ class PortForward(_PortForward):
 
     def stop(self):
         """Stop the background thread."""
-        while self.server is None:
-            time.sleep(0.1)
-        self.server.close()
+        for server in self.servers:
+            while server is None:
+                time.sleep(0.1)
+            server.close()
+

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -21,4 +21,3 @@ class PortForward(_PortForward):
             while server is None:
                 time.sleep(0.1)
             server.close()
-

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -495,6 +495,8 @@ async def test_pod_logs(example_pod_spec):
 async def test_pod_port_forward_context_manager(nginx_service):
     [nginx_pod, *_] = await nginx_service.ready_pods()
     async with nginx_pod.portforward(80) as port:
+        print("STARTING PF")
+        print(port)
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as session:
             resp = await session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -495,8 +495,6 @@ async def test_pod_logs(example_pod_spec):
 async def test_pod_port_forward_context_manager(nginx_service):
     [nginx_pod, *_] = await nginx_service.ready_pods()
     async with nginx_pod.portforward(80) as port:
-        print("STARTING PF")
-        print(port)
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as session:
             resp = await session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -585,6 +585,7 @@ async def test_multiple_bind_addresses_port_forward(nginx_service):
     # Stop the port forwarding
     await pf.stop()
 
+
 async def test_scalable_dot_notation():
     class Foo(APIObject):
         version = "foo.kr8s.org/v1alpha1"


### PR DESCRIPTION
### Overview
This pull request introduces a new feature that allows users to specify a custom bind address for port forwarding within the `kr8s` project. This enhancement provides greater flexibility in network configurations and enhances usability for environments requiring specific binding settings.

### Changes
- Added functionality to choose a custom bind address for port forwarding.
- Updated relevant methods to handle the additional parameter for the bind address.
- Ensured backward compatibility with existing function calls by setting default bind address values.

### Impact
- Users can now define a specific bind address when setting up port forwarding, offering better control over network traffic routing.
- No impact on existing functionality; all previous configurations without a specified bind address will continue to work as before.

### Tests
- Conducted tests to ensure that the new feature works as expected in various scenarios.
- Ensured that all existing tests pass without modifications, confirming backward compatibility.

### How to Test
1. Update to the latest version of the `kr8s` project.
2. Utilize the new parameter for specifying the bind address in your port forwarding setup.
3. Verify that the port forwarding works as expected with the custom bind address.

Your feedback and suggestions on this feature are greatly appreciated!
