### PR TITLE
Disable codecov patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: 90
         threshold: 1%
+    patch: off


### PR DESCRIPTION
I find myself often ignoring the patch check from codecov and just focusing on the overall project coverage, so going to disable it to reduce false positive failure noise.