### PR TITLE
Use PyPI version of pytest-kind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 test = [
     "pytest>=7.2.2",
     "pytest-asyncio>=0.20.3",
-    "pytest-kind@git+https://codeberg.org/hjacobs/pytest-kind.git",
+    "pytest-kind>=22.11.1",
     "pytest-timeout>=2.1.0",
     "pytest-rerunfailures>=11.1.2",
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
Pushing to PyPI is currently failing as the `pytest-kind` dependency is directly pointing to GitHub.

I seem to remember doing this because we needed some unreleased fix from `pytest-kind`, but that may have been a hangover from `dask-kubernetes` and no longer needed.