### PR TITLE
Fix sync objects_from_files

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1620,6 +1620,8 @@ async def objects_from_files(
         files = [f for f in path.glob(pattern) if f.is_file()]
     else:
         files = [path]
+    if not api:
+        api = await kr8s.asyncio.api(_asyncio=_asyncio)
     objects = []
     for file in files:
         with open(file, "r") as f:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -631,6 +631,8 @@ def test_objects_from_file_sync():
     assert len(objects) == 2
     assert isinstance(objects[0], Pod)
     assert isinstance(objects[1], Service)
+    assert not objects[0]._asyncio
+    assert not objects[0].api._asyncio
     assert len(objects[1].spec.ports) == 1
 
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -24,6 +24,7 @@ from kr8s.asyncio.objects import (
 from kr8s.asyncio.portforward import PortForward
 from kr8s.objects import Pod as SyncPod
 from kr8s.objects import get_class, new_class, object_from_spec
+from kr8s.objects import objects_from_files as sync_objects_from_files
 
 DEFAULT_TIMEOUT = httpx.Timeout(30)
 CURRENT_DIR = pathlib.Path(__file__).parent
@@ -615,6 +616,16 @@ async def test_object_from_file():
 
 async def test_objects_from_file():
     objects = await objects_from_files(
+        CURRENT_DIR / "resources" / "simple" / "nginx_pod_service.yaml"
+    )
+    assert len(objects) == 2
+    assert isinstance(objects[0], Pod)
+    assert isinstance(objects[1], Service)
+    assert len(objects[1].spec.ports) == 1
+
+
+def test_objects_from_file_sync():
+    objects = sync_objects_from_files(
         CURRENT_DIR / "resources" / "simple" / "nginx_pod_service.yaml"
     )
     assert len(objects) == 2


### PR DESCRIPTION
Instead of passing `api=None` all the way down to the object instantiation we can grab an api reference while in the `object_from_files` coroutine and either grab a sync or async API using `kr8s.asyncio.api(_asyncio=...)`.

Fixes #272 