### PR TITLE
Update kubectl-ng pins during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,29 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
   publish-kubectl-ng:
     runs-on: ubuntu-latest
+    needs: publish-kr8s
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Update kr8s pin in kubectl-ng
+        run: |
+          pushd examples/kubectl-ng
+          poetry add kr8s==${RELEASE_VERSION}
+          poetry lock
+          popd
+          git config --global user.name 'Kr8s Bot'
+          git config --global user.email 'kr8s-bot@users.noreply.github.com'
+          git commit -am "Bumping kubectl-ng pin to ${RELEASE_VERSION}"
+          git push
       - name: Publish kubectl-ng
         uses: JRubics/poetry-publish@v1.16
         with:

--- a/examples/kubectl-ng/poetry.lock
+++ b/examples/kubectl-ng/poetry.lock
@@ -1619,4 +1619,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ffff5e9dcc12d57f41dbe90aec14f632ed656267c427047354aeed037c53dc50"
+content-hash = "ce07c6941fd92895b2c17f520ede137cb92f1949a573b2e957a11f7419b6c01c"

--- a/examples/kubectl-ng/poetry.lock
+++ b/examples/kubectl-ng/poetry.lock
@@ -782,13 +782,13 @@ test = ["kubernetes (>=26.1.0)", "kubernetes-asyncio (>=24.2.3)", "kubernetes-va
 
 [[package]]
 name = "kubernetes-validate"
-version = "1.28.3"
+version = "1.29.0"
 description = "validates kubernetes resource definitions against schemas"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "kubernetes-validate-1.28.3.tar.gz", hash = "sha256:f8dbc7af04900f235d478bc4c41e4480b7e5f50521fdc90a6df4e843f851f16f"},
+    {file = "kubernetes-validate-1.29.0.tar.gz", hash = "sha256:a497ecea3407b10cdd00ee682fb095f1197c24b60f8eff03bf6cd0026aa3a8d4"},
 ]
 
 [package.dependencies]
@@ -796,6 +796,7 @@ importlib-resources = "*"
 jsonschema = "*"
 packaging = "*"
 PyYAML = "*"
+referencing = "*"
 typing-extensions = "*"
 
 [[package]]
@@ -1619,4 +1620,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "ce07c6941fd92895b2c17f520ede137cb92f1949a573b2e957a11f7419b6c01c"
+content-hash = "ffff5e9dcc12d57f41dbe90aec14f632ed656267c427047354aeed037c53dc50"

--- a/examples/kubectl-ng/pyproject.toml
+++ b/examples/kubectl-ng/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "kubectl_ng" }]
 python = "^3.9"
 typer = "^0.7.0"
 rich = "^13.3.2"
-kr8s = "^0.12.11"
+kr8s = "0.12.11"
 
 [tool.poetry.group.test]
 optional = true

--- a/examples/kubectl-ng/pyproject.toml
+++ b/examples/kubectl-ng/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "kubectl_ng" }]
 python = "^3.9"
 typer = "^0.7.0"
 rich = "^13.3.2"
-kr8s = "0.12.11"
+kr8s = "^0.12.11"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
New release workflow:
- Publish kr8s to PyPI
- Update kubectl-ng pins to new kr8s release
- Regenerate poetry lock
- Push new poetry info back to main
- Publish kubectl-ng to PyPI