### PR TITLE
Add pre-commit to set license header

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,13 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: insert-license
+        files: \.py$
+        args:
+          - --license-filepath=LICENSE_HEADER
+          - --use-current-year
+          - --no-extra-eol
+          - --detect-license-in-X-top-lines=2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
           - --license-filepath=LICENSE_HEADER
           - --use-current-year
           - --no-extra-eol
-          - --detect-license-in-X-top-lines=2
+          - --detect-license-in-X-top-lines=5

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Kr8s Developers, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+Copyright (c) 2023, Kr8s Developers: Jacob Tomlinson, NVIDIA, Dask Developers, Yuvi Panda, Anaconda Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+Copyright (c) 2023, Kr8s Developers, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Kr8s Developers: Jacob Tomlinson, NVIDIA, Dask Developers, Yuvi Panda, Anaconda Inc
+Copyright (c) 2024, Kr8s Developers: Jacob Tomlinson, NVIDIA, Dask Developers, Yuvi Panda, Anaconda Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,2 +1,2 @@
-SPDX-FileCopyrightText: Copyright (c) 0000, Dask Developers, NVIDIA
+SPDX-FileCopyrightText: Copyright (c) 0000, Kr8s Developers (See LICENSE for list)
 SPDX-License-Identifier: BSD 3-Clause License

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 0000, Dask Developers, NVIDIA
+SPDX-License-Identifier: BSD 3-Clause License

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import json
 import re
 import urllib.request

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import os
 import time
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 
 # Configuration file for the Sphinx documentation builder.

--- a/examples/kubectl-ng/kubectl_ng/__init__.py
+++ b/examples/kubectl-ng/kubectl_ng/__init__.py
@@ -1,5 +1,5 @@
-"""kubectl-ng."""
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+"""kubectl-ng."""
 
 __version__ = "0.0.0"

--- a/examples/kubectl-ng/kubectl_ng/_api_resources.py
+++ b/examples/kubectl-ng/kubectl_ng/_api_resources.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import typer
 from rich import box

--- a/examples/kubectl-ng/kubectl_ng/_create.py
+++ b/examples/kubectl-ng/kubectl_ng/_create.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 
 import typer

--- a/examples/kubectl-ng/kubectl_ng/_delete.py
+++ b/examples/kubectl-ng/kubectl_ng/_delete.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 
 import anyio

--- a/examples/kubectl-ng/kubectl_ng/_exec.py
+++ b/examples/kubectl-ng/kubectl_ng/_exec.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import sys
 from typing import List
 

--- a/examples/kubectl-ng/kubectl_ng/_formatters.py
+++ b/examples/kubectl-ng/kubectl_ng/_formatters.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from datetime import timedelta
 

--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from typing import List
 

--- a/examples/kubectl-ng/kubectl_ng/_version.py
+++ b/examples/kubectl-ng/kubectl_ng/_version.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import json
 import sys

--- a/examples/kubectl-ng/kubectl_ng/_wait.py
+++ b/examples/kubectl-ng/kubectl_ng/_wait.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 from typing import List, Optional

--- a/examples/kubectl-ng/kubectl_ng/cli.py
+++ b/examples/kubectl-ng/kubectl_ng/cli.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 from functools import wraps

--- a/examples/kubectl-ng/kubectl_ng/tests/test_create_delete.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_create_delete.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import pathlib
 
 from kubectl_ng.cli import app

--- a/examples/kubectl-ng/kubectl_ng/tests/test_exec.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_exec.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import datetime
 import pathlib
 

--- a/examples/kubectl-ng/kubectl_ng/tests/test_formatters.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_formatters.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from kubectl_ng._formatters import time_delta_to_string
 

--- a/examples/kubectl-ng/kubectl_ng/tests/test_version.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_version.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import json
 
 import yaml

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from functools import partial, update_wrapper
 

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import base64
 import json

--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 """Utilities for working with Kubernetes data structures."""
 from typing import Any, Dict, List

--- a/kr8s/_exceptions.py
+++ b/kr8s/_exceptions.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 class NotFoundError(Exception):
     """Unable to find the requested resource."""
 

--- a/kr8s/_exec.py
+++ b/kr8s/_exec.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 

--- a/kr8s/_io.py
+++ b/kr8s/_io.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Jupyter Development Team., MrNaif2018, Dask Developers, NVIDIA
-# SPDX-License-Identifier: MIT License, BSD 3-Clause License
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 #
 # This file was originally based on universalasync (commit d397911) and jupyter-core (commit 98b9a1a).
 # Both projects attempt to solve the same problem: how to run nested async tasks.

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 

--- a/kr8s/_testutils.py
+++ b/kr8s/_testutils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import contextlib
 import os

--- a/kr8s/asyncio/__init__.py
+++ b/kr8s/asyncio/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._api import Api  # noqa
 

--- a/kr8s/asyncio/_api.py
+++ b/kr8s/asyncio/_api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import threading
 

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from typing import Dict, List, Union
 

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._objects import (  # noqa
     APIObject,

--- a/kr8s/asyncio/portforward.py
+++ b/kr8s/asyncio/portforward.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._portforward import PortForward  # noqa

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import base64

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 from functools import partial
 
 from ._io import run_sync, sync

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import threading
 import time
 

--- a/kr8s/tests/scripts/envexec.py
+++ b/kr8s/tests/scripts/envexec.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 #
 # Produce a valid client.authentication.k8s.io/v1beta1 ExecCredential from

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import queue

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import base64
 import sys

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import pytest
 

--- a/kr8s/tests/test_gen.py
+++ b/kr8s/tests/test_gen.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
 import time
 
 from kr8s.objects import Pod

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import anyio
 import pytest

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import datetime

--- a/kr8s/tests/test_testutils.py
+++ b/kr8s/tests/test_testutils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023, Dask Developers, NVIDIA
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import os
 


### PR DESCRIPTION
I keep forgetting to add a license header to new files. Also it's a new year so many of the copyrights are out of date.

This PR adds a pre-commit hook to ensure new files have license headers and keeps dates up to date.