### PR TITLE
Make the default action to show help

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/cli.py
+++ b/examples/kubectl-ng/kubectl_ng/cli.py
@@ -32,7 +32,7 @@ def register(app, func, alias=None):
         app.command()(func)
 
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 register(app, api_resources)
 register(app, api_versions)
 register(app, create)

--- a/examples/kubectl-ng/kubectl_ng/tests/test_cli.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_cli.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from kubectl_ng.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_help_default():
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "Usage:" in result.stdout


### PR DESCRIPTION
Currently running bare `kubectl-ng` shows an error. Changing the default behaviour to show the help.

```console
$ kubectl-ng                                        
                                                                                                                                                                                              
 Usage: kubectl-ng [OPTIONS] COMMAND [ARGS]...                                                                                                                                                
                                                                                                                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --install-completion        [bash|zsh|fish|powershell|pwsh]  Install completion for the specified shell. [default: None]                                                                   │
│ --show-completion           [bash|zsh|fish|powershell|pwsh]  Show completion for the specified shell, to copy it or customize the installation. [default: None]                            │
│ --help                                                       Show this message and exit.                                                                                                   │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ api-resources                Print the supported API resources on the server.                                                                                                              │
│ api-versions                 Print the supported API versions on the server, in the form of "group/version".                                                                               │
│ create                                                                                                                                                                                     │
│ delete                                                                                                                                                                                     │
│ exec                         Execute a command in a container.                                                                                                                             │
│ get                          Display one or many resources.                                                                                                                                │
│ version                      Print the client and server version information for the current context.                                                                                      │
│ wait                         Wait for a specific condition on one or many resources.                                                                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```