### PR TITLE
Change title hierarchy of more examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -334,9 +334,10 @@ await pf.stop()
 
 `````
 
-```{seealso}
+### More examples
+
 See the [Examples Documentation](examples/index) for a full set of examples.
-```
+
 
 ```{toctree}
 :maxdepth: 2


### PR DESCRIPTION
Instead of using a `seealso` block at the end of the examples so link to the full examples section I'm updating it to be an `h3` so that it shows up in the right hand nav.

