### PR TITLE
Change wait to match any condition, add mode to enable previous funtionality

### DIFF
--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -92,6 +92,38 @@ while not await pod.ready():
 
 `````
 
+## Create a Job and wait for it to either succeed or fail
+
+Create a new {py:class}`Job <kr8s.objects.Job>` and wait for it to either succeed or fail with {py:func}`Job.wait() <kr8s.objects.Job.wait()>`.
+
+`````{tab-set}
+
+````{tab-item} Sync
+:sync: sync
+```python
+from kr8s.objects import Job
+
+job = Job(...)
+job.create()
+
+job.wait(["condition=Complete", "condition=Failed"])
+```
+````
+
+````{tab-item} Async
+:sync: async
+```python
+from kr8s.asyncio.objects import Jod
+
+job = await Job(...)
+await job.create()
+
+await job.wait(["condition=Complete", "condition=Failed"])
+```
+````
+
+`````
+
 ## Create a Secret
 
 Create a {py:class}`Secret <kr8s.objects.Secret>` with several keys.

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -442,6 +442,12 @@ class APIObject:
             >>> job = Job.get("my-jod")
             >>> job.wait(["condition=Complete", "condition=Failed"])
 
+            Wait for a Pod to be initialized and ready to start containers.
+
+            >>> from kr8s.objects import Pod
+            >>> pod = Pod.get("my-pod")
+            >>> pod.wait(["condition=Initialized", "condition=PodReadyToStartContainers"], mode="all")
+
         Note:
             As of the current Kubertenetes release when this function was written (1.29) kubectl doesn't support
             multiple conditions. There is a PR to implement this but it hasn't been merged yet

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -9,7 +9,17 @@ import pathlib
 import re
 import sys
 import time
-from typing import Any, AsyncGenerator, BinaryIO, Dict, List, Optional, Type, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    BinaryIO,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
 
 import anyio
 import httpx
@@ -39,6 +49,8 @@ if sys.version_info >= (3, 11):
     APIObjectType = Self
 else:
     APIObjectType = "APIObject"
+
+WaitMode = Literal["AND", "OR", "wait", "wait-for"]
 
 
 class APIObject:
@@ -361,8 +373,17 @@ class APIObject:
         api = await kr8s.asyncio.api()
         return await api._get(kind=cls, **kwargs)
 
-    async def _test_conditions(self, conditions: list) -> bool:
-        """Test if conditions are met."""
+    async def _test_conditions(self, conditions: list, mode: WaitMode = "OR") -> bool:
+        """Test if conditions are met.
+
+        Args:
+            conditions: A list of conditions to test.
+            mode: Match any condition with "OR" or all conditions with "AND". Defaults to "OR".
+
+        Returns:
+            bool: True if any condition is met, False otherwise.
+        """
+        results = []
         for condition in conditions:
             if condition.startswith("condition"):
                 condition = "=".join(condition.split("=")[1:])
@@ -377,24 +398,58 @@ class APIObject:
                 status_conditions = list_dict_unpack(
                     self.status.get("conditions", []), "type", "status"
                 )
-                if status_conditions.get(field, None) != value:
-                    return False
+                results.append(status_conditions.get(field, None) == value)
             elif condition == "delete":
-                if await self._exists():
-                    return False
+                results.append(not await self._exists())
             elif condition.startswith("jsonpath"):
                 matches = re.search(JSONPATH_CONDITION_EXPRESSION, condition)
                 expression = matches.group("expression")
                 condition = matches.group("condition")
                 [value] = jsonpath.findall(expression, self._raw)
-                if value != condition:
-                    return False
+                results.append(value == condition)
             else:
                 raise ValueError(f"Unknown condition type {condition}")
-        return True
+        if mode == "AND" or mode == "wait-for":
+            return all(results)
+        elif mode == "OR" or mode == "wait":
+            return any(results)
+        else:
+            raise ValueError(f"Unknown wait mode {mode}")
 
-    async def wait(self, conditions: Union[List[str], str], timeout: int = None):
-        """Wait for conditions to be met."""
+    async def wait(
+        self,
+        conditions: Union[List[str], str],
+        mode: WaitMode = "OR",
+        timeout: int = None,
+    ):
+        """Wait for conditions to be met.
+
+        Args:
+            conditions: A list of conditions to wait for.
+            mode: Match any condition with "OR" or all conditions with "AND". Defaults to "OR".
+            timeout: Timeout in seconds.
+
+        Example:
+            Wait for a Pod to be ready.
+
+            >>> from kr8s.objects import Pod
+            >>> pod = Pod.get("my-pod")
+            >>> pod.wait("condition=Ready")
+
+            Wait for a Job to either succeed or fail.
+
+            >>> from kr8s.objects import Job
+            >>> job = Job.get("my-jod")
+            >>> job.wait(["condition=Complete", "condition=Failed"])
+
+        Note:
+            As of the current Kubertenetes release when this function was written (1.29) kubectl doesn't support
+            multiple conditions. There is a PR to implement this but it hasn't been merged yet
+            https://github.com/kubernetes/kubernetes/pull/119205.
+
+            Given that ``for`` is a reserved word anyway we can't exactly match the kubectl API so
+            we use ``condition`` in combination with a ``mode`` instead.
+        """
         if isinstance(conditions, str):
             conditions = [conditions]
 
@@ -404,10 +459,10 @@ class APIObject:
             except NotFoundError:
                 if set(conditions) == {"delete"}:
                     return
-            if await self._test_conditions(conditions):
+            if await self._test_conditions(conditions, mode=mode):
                 return
             async for _ in self._watch():
-                if await self._test_conditions(conditions):
+                if await self._test_conditions(conditions, mode=mode):
                     return
 
     async def annotate(self, annotations: dict = None, **kwargs) -> None:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -137,6 +137,13 @@ async def test_pod_wait_ready(example_pod_spec):
     await pod.wait("delete")
 
 
+async def test_pod_wait_multiple_conditions(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    await pod.wait(conditions=["condition=Failed", "condition=Ready"])
+    await pod.delete()
+
+
 def test_pod_wait_ready_sync(example_pod_spec):
     pod = SyncPod(example_pod_spec)
     pod.create()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -141,6 +141,19 @@ async def test_pod_wait_multiple_conditions(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()
     await pod.wait(conditions=["condition=Failed", "condition=Ready"])
+    with pytest.raises(TimeoutError):
+        await pod.wait(
+            conditions=["condition=Failed", "condition=Ready"], mode="all", timeout=0.1
+        )
+    await pod.wait(
+        conditions=[
+            "condition=Initialized",
+            "condition=ContainersReady",
+        ],
+        mode="all",
+    )
+    with pytest.raises(ValueError):
+        await pod.wait(conditions=["condition=Failed", "condition=Ready"], mode="foo")
     await pod.delete()
 
 


### PR DESCRIPTION
Closes #292.

Currently in `resource.wait(conditions=...)` we support multiple conditions and test them using a logical AND.

It seems like `kubectl` doesn't support multiple conditions, but in the proposed implementation https://github.com/kubernetes/kubernetes/pull/119205 the default behaviour will be a logical OR with the option change it to a logical AND using a new `--for-all` flag.

Given that `for` is a reserved word in Python we can't have a `for` kwarg anyway and have gone with `conditions`, so even when `--for-all` is implemented we can't get any closer to that syntax. 

Instead in this PR I've added a `mode` which can be set to `"any"` or `"all"` and defaults to `"any"` to match the proposed `kubectl` behaviour. 

```python
from kr8s.objects import Job
job = Job.get("my-jod")

# Wait for the job to either succeed or fail
job.wait(["condition=Complete", "condition=Failed"])
```

This is a minor breaking change for current users who may be used to the AND behaviour, but it's more important to match the behaviour of `kubectl`. If users need the old behaviour they can explicitly set the mode back to `"all"`.

```python
# Wait for the resource to be Available and not Processing
resource.wait(["condition=Available", "condition=Processing=False"], mode="all")
```