### PR TITLE
Fix types when checking wait conditions

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -406,7 +406,7 @@ class APIObject:
                 expression = matches.group("expression")
                 condition = matches.group("condition")
                 [value] = jsonpath.findall(expression, self._raw)
-                results.append(value == condition)
+                results.append(str(value) == str(condition))
             else:
                 raise ValueError(f"Unknown condition type {condition}")
         if mode == "any":

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -173,6 +173,47 @@ def test_pod_wait_ready_sync(example_pod_spec):
     pod.wait("delete")
 
 
+def test_wait_replicas(ns):
+    from kr8s.objects import StatefulSet
+
+    ss = StatefulSet(
+        {
+            "metadata": {
+                "name": "test-wait-replicas",
+                "namespace": ns,
+            },
+            "spec": {
+                "replicas": 3,
+                "selector": {
+                    "matchLabels": {
+                        "app": "test-wait-replicas",
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "test-wait-replicas",
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "test-wait-replicas",
+                                "image": "nginx:latest",
+                            }
+                        ]
+                    },
+                },
+            },
+        }
+    )
+    ss.create()
+    try:
+        ss.wait("jsonpath='{.status.availableReplicas}'=3", timeout=30)
+    finally:
+        ss.delete()
+
+
 def test_pod_refresh_sync(example_pod_spec):
     pod = SyncPod(example_pod_spec)
     pod.create()


### PR DESCRIPTION
Closes #297 

When calling `ss.wait("jsonpath='{.status.availableReplicas}'=3")` the check was comparing the integer `3` with the string `"3"` which is never equivalent.

Given that we always check equivalency and not ops like `>` or `<` we can cast both sides of the check to a string before comparing.