### PR TITLE
Ensure reauthenticate calls exec again

### DIFF
--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -138,8 +138,13 @@ async def test_bad_auth(serviceaccount):
 async def test_url(kubectl_proxy):
     api = await kr8s.asyncio.api(url=kubectl_proxy)
     assert await api.get("pods", namespace="kube-system")
+    assert api.auth.server == kubectl_proxy
+
+    # Ensure reauthentication works
+    api.auth.server = None
     await api.reauthenticate()
     assert await api.get("pods", namespace="kube-system")
+    assert api.auth.server == kubectl_proxy
 
 
 def test_no_config():
@@ -164,11 +169,14 @@ async def test_service_account(serviceaccount):
 async def test_exec(kubeconfig_with_exec):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_exec)
     assert await api.get("pods", namespace=kr8s.ALL)
+    assert api.auth.server
     assert api.auth.server_ca_file
 
     # Test reauthentication
+    api.auth.server = None
     api.auth.server_ca_file = None
     await api.reauthenticate()
+    assert api.auth.server
     assert api.auth.server_ca_file
 
 

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -137,8 +137,9 @@ async def test_bad_auth(serviceaccount):
 
 async def test_url(kubectl_proxy):
     api = await kr8s.asyncio.api(url=kubectl_proxy)
-    version = await api.version()
-    assert "major" in version
+    assert await api.get("pods", namespace="kube-system")
+    await api.reauthenticate()
+    assert await api.get("pods", namespace="kube-system")
 
 
 def test_no_config():
@@ -163,6 +164,12 @@ async def test_service_account(serviceaccount):
 async def test_exec(kubeconfig_with_exec):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_exec)
     assert await api.get("pods", namespace=kr8s.ALL)
+    assert api.auth.server_ca_file
+
+    # Test reauthentication
+    api.auth.server_ca_file = None
+    await api.reauthenticate()
+    assert api.auth.server_ca_file
 
 
 async def test_token(kubeconfig_with_token):


### PR DESCRIPTION
`KubeAuth.server` was being used to store both the user specified `url` kwarg and also the url loaded from the kube config. 

When loading the kubeconfig we check that the server hasn't been set because we don't want to overwrite a url set by the user. However after the first authentication from kubeconfig that attribute is set, so when we call reauthenticate it looks like a user has specified the url and we never refresh it, so we aren't actually reauthenticating at all.

This PR creates a new `_url` attribute to store the user specified url which allows us to differentiate between them.

Updated a couple of tests to ensure that a user specified URL doesn't get overwritten, but a kubectl specified url (and other attributes) get reloaded when we reauthenticate.

Closes #306 