### PR TITLE
Only load service account of kubeconfig was not found

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -58,7 +58,7 @@ class KubeAuth:
             else:
                 if self._kubeconfig is not False:
                     await self._load_kubeconfig()
-                if self._serviceaccount:
+                if self._serviceaccount and not self.server:
                     await self._load_service_account()
             if not self.server:
                 raise ValueError("Unable to find valid credentials")


### PR DESCRIPTION
In #309 a regression was found that was caused by #307. If the config is successfully loaded from the kube config then authentication should end.

Closes #309 