### PR TITLE
Fix sync Service.ready_pods()

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1226,7 +1226,7 @@ class Service(APIObject):
             label_selector=dict_to_selector(self.spec["selector"]),
             namespace=self.namespace,
         )
-        return [pod for pod in pods if await pod.ready()]
+        return [pod for pod in pods if await pod._ready()]
 
     async def ready(self) -> bool:
         """Check if the service is ready."""


### PR DESCRIPTION
`Service.ready_pods()` is calling `Pod.ready()` which means for a sync `Service` the coroutine wrapped is called within the event loop.

This PR updates to use `Pod._ready()` and adds a test to verify it works.