### PR TITLE
Change private async methods to async_ prefix

### DIFF
--- a/kr8s/_io.py
+++ b/kr8s/_io.py
@@ -112,7 +112,7 @@ def sync(source: object) -> object:
     for name in dir(source):
         method = getattr(source, name)
 
-        if not name.startswith("_"):
+        if not name.startswith("_") and not name.startswith("async_"):
             if inspect.iscoroutinefunction(method) or inspect.isasyncgenfunction(
                 method
             ):

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -180,9 +180,9 @@ class PortForward:
         if isinstance(self._resource, Pod):
             return self._resource
 
-        if hasattr(self._resource, "ready_pods"):
+        if hasattr(self._resource, "async_ready_pods"):
             try:
-                return random.choice(await self._resource.ready_pods())
+                return random.choice(await self._resource.async_ready_pods())
             except IndexError:
                 raise RuntimeError("No ready pods found")
 

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -62,7 +62,7 @@ async def get(
     """
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api._get(
+    return await api.async_get(
         kind,
         *names,
         namespace=namespace,
@@ -76,7 +76,7 @@ async def get(
 async def version(api=None, _asyncio=True):
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api._version()
+    return await api.async_version()
 
 
 async def watch(
@@ -90,7 +90,7 @@ async def watch(
 ):
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    async for t, o in api._watch(
+    async for t, o in api.async_watch(
         kind=kind,
         namespace=namespace,
         label_selector=label_selector,
@@ -103,13 +103,13 @@ async def watch(
 async def api_resources(api=None, _asyncio=True):
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api._api_resources()
+    return await api.async_api_resources()
 
 
 async def whoami(api=None, _asyncio=True):
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api._whoami()
+    return await api.async_whoami()
 
 
 get.__doc__ = Api.get.__doc__

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -570,12 +570,10 @@ async def test_pod_port_forward_context_manager(nginx_service):
 
 
 def test_pod_port_forward_context_manager_sync(nginx_service):
-    async_nginx_service = nginx_service
     nginx_service = SyncService.get(
-        async_nginx_service.name, namespace=async_nginx_service.namespace
+        nginx_service.name, namespace=nginx_service.namespace
     )
-    [nginx_pod, *_] = nginx_service.ready_pods()
-    with nginx_pod.portforward(80) as port:
+    with nginx_service.portforward(80) as port:
         with httpx.Client(timeout=DEFAULT_TIMEOUT) as session:
             resp = session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200


### PR DESCRIPTION
Closes #319 

Rename private async methods to public `async_` prefixed methods. Allows calling async methods across objects even when the sync shim is active.