### PR TITLE
Handle key/cert data not being b64 encoded

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import base64
+import binascii
 import json
 import os
 import ssl
@@ -163,9 +164,11 @@ class KubeAuth:
                 )
         if "client-key-data" in self._user:
             async with NamedTemporaryFile(delete=False) as key_file:
-                await key_file.write_bytes(
-                    base64.b64decode(self._user["client-key-data"])
-                )
+                try:
+                    key_data = base64.b64decode(self._user["client-key-data"])
+                except binascii.Error:
+                    key_data = self._user["client-key-data"]
+                await key_file.write_bytes(key_data)
                 self.client_key_file = str(key_file)
         if "client-certificate" in self._user:
             client_cert_path = anyio.Path(self._user["client-certificate"])
@@ -177,9 +180,11 @@ class KubeAuth:
                 )
         if "client-certificate-data" in self._user:
             async with NamedTemporaryFile(delete=False) as cert_file:
-                await cert_file.write_bytes(
-                    base64.b64decode(self._user["client-certificate-data"])
-                )
+                try:
+                    cert_data = base64.b64decode(self._user["client-certificate-data"])
+                except binascii.Error:
+                    cert_data = self._user["client-certificate-data"]
+                await cert_file.write_bytes(cert_data)
                 self.client_cert_file = str(cert_file)
         if "certificate-authority" in self._cluster:
             server_ca_path = anyio.Path(self._cluster["certificate-authority"])
@@ -191,9 +196,13 @@ class KubeAuth:
                 )
         if "certificate-authority-data" in self._cluster:
             async with NamedTemporaryFile(delete=False) as ca_file:
-                await ca_file.write_bytes(
-                    base64.b64decode(self._cluster["certificate-authority-data"])
-                )
+                try:
+                    ca_data = base64.b64decode(
+                        self._cluster["certificate-authority-data"]
+                    )
+                except binascii.Error:
+                    ca_data = self._cluster["certificate-authority-data"]
+                await ca_file.write_bytes(ca_data)
                 self.server_ca_file = str(ca_file)
         if "token" in self._user:
             self.token = self._user["token"]

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -165,9 +165,11 @@ class KubeAuth:
         if "client-key-data" in self._user:
             async with NamedTemporaryFile(delete=False) as key_file:
                 try:
-                    key_data = base64.b64decode(self._user["client-key-data"])
+                    key_data = base64.b64decode(
+                        self._user["client-key-data"], validate=True
+                    )
                 except binascii.Error:
-                    key_data = self._user["client-key-data"]
+                    key_data = self._user["client-key-data"].encode()
                 await key_file.write_bytes(key_data)
                 self.client_key_file = str(key_file)
         if "client-certificate" in self._user:
@@ -181,9 +183,11 @@ class KubeAuth:
         if "client-certificate-data" in self._user:
             async with NamedTemporaryFile(delete=False) as cert_file:
                 try:
-                    cert_data = base64.b64decode(self._user["client-certificate-data"])
+                    cert_data = base64.b64decode(
+                        self._user["client-certificate-data"], validate=True
+                    )
                 except binascii.Error:
-                    cert_data = self._user["client-certificate-data"]
+                    cert_data = self._user["client-certificate-data"].encode()
                 await cert_file.write_bytes(cert_data)
                 self.client_cert_file = str(cert_file)
         if "certificate-authority" in self._cluster:
@@ -198,10 +202,10 @@ class KubeAuth:
             async with NamedTemporaryFile(delete=False) as ca_file:
                 try:
                     ca_data = base64.b64decode(
-                        self._cluster["certificate-authority-data"]
+                        self._cluster["certificate-authority-data"], validate=True
                     )
                 except binascii.Error:
-                    ca_data = self._cluster["certificate-authority-data"]
+                    ca_data = self._cluster["certificate-authority-data"].encode()
                 await ca_file.write_bytes(ca_data)
                 self.server_ca_file = str(ca_file)
         if "token" in self._user:


### PR DESCRIPTION
Closes #323

If decoding a key/cert try again without decoding it, to handle cases where they aren't encoded.