### PR TITLE
Add link to missing object exception

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1595,7 +1595,11 @@ def get_class(
             ):
                 return cls
 
-    raise KeyError(f"No object registered for {kind}{'.' + group if group else ''}")
+    raise KeyError(
+        f"No object registered for {kind}{'.' + group if group else ''}. "
+        "See https://docs.kr8s.org/en/stable/object.html#extending-the-objects-api "
+        "for more information on how to register a new object."
+    )
 
 
 def new_class(


### PR DESCRIPTION
Follow up to #325 to point users in the right direction when they get a `No object registered for foo` exception.