### PR TITLE
Migrate `kr8s._io.check_output()` to use `anyio`

### DIFF
--- a/kr8s/_io.py
+++ b/kr8s/_io.py
@@ -12,8 +12,8 @@
 # asyncio or trio.
 from __future__ import annotations
 
-import asyncio
 import inspect
+import subprocess
 import tempfile
 from contextlib import asynccontextmanager
 from functools import partial, wraps
@@ -130,18 +130,18 @@ def sync(source: object) -> object:
 
 async def check_output(*args, **kwargs) -> str:
     """Run a command and return its output."""
-    p = await asyncio.create_subprocess_exec(
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    completed_process = await anyio.run_process(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
         **kwargs,
     )
-    stdout_data, stderr_data = await p.communicate()
-    if p.returncode == 0:
-        return stdout_data.decode()
+    if completed_process.returncode == 0:
+        return completed_process.stdout.decode()
     else:
         raise RuntimeError(
-            f"Process exited with non-zero code {p.returncode}:\n{stderr_data.decode()}"
+            f"Process exited with non-zero code {completed_process.returncode}:\n{completed_process.stderr.decode()}"
         )
 
 

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -59,3 +59,11 @@ async def test_tempfiles():
         assert await f.exists()
         assert isinstance(f, anyio.Path)
     assert not await f.exists()
+
+
+async def test_check_output():
+    output = await kr8s._io.check_output("echo", "hello")
+    assert output == "hello\n"
+
+    with pytest.raises(RuntimeError, match="non-zero code"):
+        await kr8s._io.check_output("false")


### PR DESCRIPTION
Closes #332