### PR TITLE
Suppress WebSocketDisconnect in _portforward._sync_sockets .

### DIFF
--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -217,7 +217,7 @@ class PortForward:
         """Start two tasks to copy bytes from tcp=>websocket and websocket=>tcp."""
         try:
             async with self._connect_websocket() as ws:
-                with suppress(ConnectionClosedError):
+                with suppress(ConnectionClosedError, httpx_ws.WebSocketDisconnect):
                     async with anyio.create_task_group() as tg:
                         tg.start_soon(self._tcp_to_ws, ws, reader)
                         tg.start_soon(self._ws_to_tcp, ws, writer)


### PR DESCRIPTION
With the switching to `httpx_ws` of `exec` and `portforward`, the `WebSocketDisconnect` exception is not suppressed in `_portforward._sync_sockets`. This can cause spurious messages due to the exception not being captured in the Task Group.

This PR simply adds `WebSocketDisconnect` to the list of exceptions suppressed in `_portforward._sync_sockets`.