### PR TITLE
Allow client.authentication.k8s.io/v1 client authentication

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -137,8 +137,7 @@ class KubeAuth:
                 == "client.authentication.k8s.io/v1alpha1"
             ):
                 raise ValueError(
-                    "Only client.authentication.k8s.io/v1beta1 or "
-                    "client.authentication.k8s.io/v1 is supported for exec auth"
+                    "client.authentication.k8s.io/v1alpha1 is not supported for exec auth"
                 )
             command = self._user["exec"]["command"]
             args = self._user["exec"].get("args") or []

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -132,12 +132,13 @@ class KubeAuth:
             self._insecure_skip_tls_verify = True
 
         if "exec" in self._user:
-            if (
-                self._user["exec"]["apiVersion"]
-                != "client.authentication.k8s.io/v1beta1"
-            ):
+            if self._user["exec"]["apiVersion"] not in [
+                "client.authentication.k8s.io/v1beta1",
+                "client.authentication.k8s.io/v1",
+            ]:
                 raise ValueError(
-                    "Only client.authentication.k8s.io/v1beta1 is supported for exec auth"
+                    "Only client.authentication.k8s.io/v1beta1 or "
+                    "client.authentication.k8s.io/v1 is supported for exec auth"
                 )
             command = self._user["exec"]["command"]
             args = self._user["exec"].get("args") or []

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -132,10 +132,10 @@ class KubeAuth:
             self._insecure_skip_tls_verify = True
 
         if "exec" in self._user:
-            if self._user["exec"]["apiVersion"] not in [
-                "client.authentication.k8s.io/v1beta1",
-                "client.authentication.k8s.io/v1",
-            ]:
+            if (
+                self._user["exec"]["apiVersion"]
+                == "client.authentication.k8s.io/v1alpha1"
+            ):
                 raise ValueError(
                     "Only client.authentication.k8s.io/v1beta1 or "
                     "client.authentication.k8s.io/v1 is supported for exec auth"


### PR DESCRIPTION
Closes #345 

The main intent of the check is to disallow `client.authentication.k8s.io/v1alpha1` so inverted the logic here to allow for newer versions.