### PR TITLE
Add support for multiple kubeconfig files

### DIFF
--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+import anyio
+import yaml
+
+# TODO Implement raw
+# TODO Implement set
+# TODO Implement unset
+# TODO Implement set cluster
+# TODO Implement delete cluster
+# TODO Implement set context
+# TODO Implement rename context
+# TODO Implement delete context
+# TODO Implement set user
+# TODO Implement delete user
+
+
+class KubeConfigSet(object):
+    def __init__(self, *paths):
+        self._configs = [KubeConfig(path) for path in paths]
+
+    def __await__(self):
+        async def f():
+            for config in self._configs:
+                await config
+            return self
+
+        return f().__await__()
+
+    async def save(self):
+        for config in self._configs:
+            await config.save()
+
+    @property
+    def raw(self):
+        raise NotImplementedError("raw not implemented")
+
+    @property
+    def current_context(self):
+        """Return the current context from the first kubeconfig.
+
+        Context configuration from multiples files are ignored.
+        """
+        return self._configs[0].current_context
+
+    async def use_context(self, context: str):
+        """Set the current context."""
+        await self._configs[0].use_context(context)
+
+    @property
+    def preferences(self):
+        raise NotImplementedError("preferences not implemented")
+
+    @property
+    def clusters(self):
+        return [cluster for config in self._configs for cluster in config.clusters]
+
+    @property
+    def users(self):
+        return [user for config in self._configs for user in config.users]
+
+    @property
+    def contexts(self):
+        return [context for config in self._configs for context in config.contexts]
+
+
+class KubeConfig(object):
+    def __init__(self, path):
+        self.path = path
+        self._raw = None
+        self.__write_lock = anyio.Lock()
+
+    def __await__(self):
+        async def f():
+            async with await anyio.open_file(self.path) as fh:
+                self._raw = yaml.safe_load(await fh.read())
+            return self
+
+        return f().__await__()
+
+    async def save(self):
+        async with self.__write_lock:
+            async with await anyio.open_file(self.path, "w") as fh:
+                await fh.write(yaml.safe_dump(self._raw))
+
+    @property
+    def current_context(self):
+        return self._raw["current-context"]
+
+    async def use_context(self, context: str):
+        """Set the current context."""
+        self._raw["current-context"] = context
+        await self.save()
+
+    @property
+    def raw(self):
+        return self._raw
+
+    @property
+    def preferences(self):
+        return self._raw["preferences"]
+
+    @property
+    def clusters(self):
+        return self._raw["clusters"]
+
+    @property
+    def users(self):
+        return self._raw["users"]
+
+    @property
+    def contexts(self):
+        return self._raw["contexts"]

--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -32,6 +32,24 @@ class KubeConfigSet(object):
             await config.save()
 
     @property
+    def path(self) -> str:
+        return self.get_path()
+
+    def get_path(self, context: str = None) -> str:
+        """Return the path of the config for the current context.
+
+        Args:
+            context (str): Override the context to use. If not provided, the current context is used.
+        """
+        if not context:
+            context = self.current_context
+        if context:
+            for config in self._configs:
+                if context in [c["name"] for c in config.contexts]:
+                    return config.path
+        return self._configs[0].path
+
+    @property
     def raw(self) -> Dict:
         """Merge all kubeconfig data into a single kubeconfig."""
         data = {
@@ -70,6 +88,27 @@ class KubeConfigSet(object):
                     await self.use_context(new)
                 return
         raise ValueError(f"Context {old} not found")
+
+    def get_context(self, context_name: str) -> Dict:
+        """Get a context by name."""
+        for context in self.contexts:
+            if context["name"] == context_name:
+                return context["context"]
+        raise ValueError(f"Context {context_name} not found")
+
+    def get_cluster(self, cluster_name: str) -> Dict:
+        """Get a cluster by name."""
+        for cluster in self.clusters:
+            if cluster["name"] == cluster_name:
+                return cluster["cluster"]
+        raise ValueError(f"Cluster {cluster_name} not found")
+
+    def get_user(self, user_name: str) -> Dict:
+        """Get a user by name."""
+        for user in self.users:
+            if user["name"] == user_name:
+                return user["user"]
+        raise ValueError(f"User {user_name} not found")
 
     @property
     def preferences(self) -> Dict:
@@ -135,6 +174,27 @@ class KubeConfig(object):
                 return
         raise ValueError(f"Context {old} not found")
 
+    def get_context(self, context_name: str) -> Dict:
+        """Get a context by name."""
+        for context in self.contexts:
+            if context["name"] == context_name:
+                return context["context"]
+        raise ValueError(f"Context {context_name} not found")
+
+    def get_cluster(self, cluster_name: str) -> Dict:
+        """Get a cluster by name."""
+        for cluster in self.clusters:
+            if cluster["name"] == cluster_name:
+                return cluster["cluster"]
+        raise ValueError(f"Cluster {cluster_name} not found")
+
+    def get_user(self, user_name: str) -> Dict:
+        """Get a user by name."""
+        for user in self.users:
+            if user["name"] == user_name:
+                return user["user"]
+        raise ValueError(f"User {user_name} not found")
+
     @property
     def raw(self) -> Dict:
         return self._raw
@@ -157,4 +217,4 @@ class KubeConfig(object):
 
     @property
     def extensions(self) -> List[Dict]:
-        return self._raw["extensions"]
+        return self._raw["extensions"] if "extensions" in self._raw else []

--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -1,15 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+from typing import Dict, List
+
 import anyio
 import yaml
 
-# TODO Implement raw
 # TODO Implement set
 # TODO Implement unset
 # TODO Implement set cluster
 # TODO Implement delete cluster
 # TODO Implement set context
-# TODO Implement rename context
 # TODO Implement delete context
 # TODO Implement set user
 # TODO Implement delete user
@@ -32,36 +32,66 @@ class KubeConfigSet(object):
             await config.save()
 
     @property
-    def raw(self):
-        raise NotImplementedError("raw not implemented")
+    def raw(self) -> Dict:
+        """Merge all kubeconfig data into a single kubeconfig."""
+        data = {
+            "apiVersion": "v1",
+            "kind": "Config",
+            "preferences": self.preferences,
+            "clusters": self.clusters,
+            "users": self.users,
+            "contexts": self.contexts,
+            "current-context": self.current_context,
+        }
+        if self.extensions:
+            data["extensions"] = self.extensions
+        return data
 
     @property
-    def current_context(self):
+    def current_context(self) -> str:
         """Return the current context from the first kubeconfig.
 
         Context configuration from multiples files are ignored.
         """
         return self._configs[0].current_context
 
-    async def use_context(self, context: str):
+    async def use_context(self, context: str) -> None:
         """Set the current context."""
-        await self._configs[0].use_context(context)
+        if context not in [c["name"] for c in self.contexts]:
+            raise ValueError(f"Context {context} not found")
+        await self._configs[0].use_context(context, allow_unknown=True)
+
+    async def rename_context(self, old: str, new: str) -> None:
+        """Rename a context."""
+        for config in self._configs:
+            if old in [c["name"] for c in config.contexts]:
+                await config.rename_context(old, new)
+                if self.current_context == old:
+                    await self.use_context(new)
+                return
+        raise ValueError(f"Context {old} not found")
 
     @property
-    def preferences(self):
-        raise NotImplementedError("preferences not implemented")
+    def preferences(self) -> Dict:
+        return self._configs[0].preferences
 
     @property
-    def clusters(self):
+    def clusters(self) -> List[Dict]:
         return [cluster for config in self._configs for cluster in config.clusters]
 
     @property
-    def users(self):
+    def users(self) -> List[Dict]:
         return [user for config in self._configs for user in config.users]
 
     @property
-    def contexts(self):
+    def contexts(self) -> List[Dict]:
         return [context for config in self._configs for context in config.contexts]
+
+    @property
+    def extensions(self) -> List[Dict]:
+        return [
+            extension for config in self._configs for extension in config.extensions
+        ]
 
 
 class KubeConfig(object):
@@ -78,36 +108,53 @@ class KubeConfig(object):
 
         return f().__await__()
 
-    async def save(self):
+    async def save(self) -> None:
         async with self.__write_lock:
             async with await anyio.open_file(self.path, "w") as fh:
                 await fh.write(yaml.safe_dump(self._raw))
 
     @property
-    def current_context(self):
+    def current_context(self) -> str:
         return self._raw["current-context"]
 
-    async def use_context(self, context: str):
+    async def use_context(self, context: str, allow_unknown: bool = False) -> None:
         """Set the current context."""
+        if not allow_unknown and context not in [c["name"] for c in self.contexts]:
+            raise ValueError(f"Context {context} not found")
         self._raw["current-context"] = context
         await self.save()
 
+    async def rename_context(self, old: str, new: str) -> None:
+        """Rename a context."""
+        for context in self._raw["contexts"]:
+            if context["name"] == old:
+                context["name"] = new
+                if self.current_context == old:
+                    await self.use_context(new)
+                await self.save()
+                return
+        raise ValueError(f"Context {old} not found")
+
     @property
-    def raw(self):
+    def raw(self) -> Dict:
         return self._raw
 
     @property
-    def preferences(self):
+    def preferences(self) -> List[Dict]:
         return self._raw["preferences"]
 
     @property
-    def clusters(self):
+    def clusters(self) -> List[Dict]:
         return self._raw["clusters"]
 
     @property
-    def users(self):
+    def users(self) -> List[Dict]:
         return self._raw["users"]
 
     @property
-    def contexts(self):
+    def contexts(self) -> List[Dict]:
         return self._raw["contexts"]
+
+    @property
+    def extensions(self) -> List[Dict]:
+        return self._raw["extensions"]

--- a/kr8s/tests/test_config.py
+++ b/kr8s/tests/test_config.py
@@ -1,12 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+from tempfile import NamedTemporaryFile
+
+import pytest
+
 from kr8s._config import KubeConfig, KubeConfigSet
 
 
-async def test_load_kubeconfig(k8s_cluster):
-    path = str(k8s_cluster.kubeconfig_path)
-    config = await KubeConfig(path)
-    assert config.path == path
+@pytest.fixture
+def temp_kubeconfig(k8s_cluster):
+    """Create a temporary kubeconfig by copying the one from k8s_cluster."""
+    with open(k8s_cluster.kubeconfig_path, "rb") as f:
+        kubeconfig = f.read()
+    with NamedTemporaryFile() as f:
+        f.write(kubeconfig)
+        f.flush()
+        yield f.name
+
+
+async def test_load_kubeconfig(temp_kubeconfig):
+    config = await KubeConfig(temp_kubeconfig)
+    assert config.path == temp_kubeconfig
     assert config._raw
     assert "current-context" in config._raw
     assert config.current_context
@@ -16,11 +30,10 @@ async def test_load_kubeconfig(k8s_cluster):
     assert len(config.contexts) > 0
 
 
-async def test_load_kubeconfig_set(k8s_cluster):
-    path = str(k8s_cluster.kubeconfig_path)
-    configs = await KubeConfigSet(path)
+async def test_load_kubeconfig_set(temp_kubeconfig):
+    configs = await KubeConfigSet(temp_kubeconfig)
     assert len(configs._configs) == 1
-    assert configs._configs[0].path == path
+    assert configs._configs[0].path == temp_kubeconfig
     assert configs._configs[0]._raw
     assert "current-context" in configs._configs[0]._raw
     assert configs.current_context
@@ -28,3 +41,23 @@ async def test_load_kubeconfig_set(k8s_cluster):
     assert "name" in configs.clusters[0]
     assert len(configs.users) > 0
     assert len(configs.contexts) > 0
+
+
+@pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])
+async def test_rename_context(temp_kubeconfig, cls):
+    config = await cls(temp_kubeconfig)
+    context = config.current_context
+    new_context = f"{context}-new"
+    assert context in [c["name"] for c in config.contexts]
+    await config.rename_context(context, new_context)
+    # Load again from disk to ensure the change was saved
+    config = await cls(temp_kubeconfig)
+    assert new_context in [c["name"] for c in config.contexts]
+    assert context not in [c["name"] for c in config.contexts]
+    assert config.current_context == new_context
+    await config.rename_context(new_context, context)
+    assert new_context not in [c["name"] for c in config.contexts]
+    assert context in [c["name"] for c in config.contexts]
+    assert config.current_context == context
+    with pytest.raises(ValueError):
+        await config.rename_context("foobar", new_context)

--- a/kr8s/tests/test_config.py
+++ b/kr8s/tests/test_config.py
@@ -61,3 +61,36 @@ async def test_rename_context(temp_kubeconfig, cls):
     assert config.current_context == context
     with pytest.raises(ValueError):
         await config.rename_context("foobar", new_context)
+
+
+@pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])
+async def test_get_context(temp_kubeconfig, cls):
+    config = await cls(temp_kubeconfig)
+    context = config.current_context
+    assert "cluster" in config.get_context(context)
+    with pytest.raises(ValueError):
+        config.get_context("foobar")
+    with pytest.raises(ValueError):
+        config.get_context("")
+
+
+@pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])
+async def test_get_cluster(temp_kubeconfig, cls):
+    config = await cls(temp_kubeconfig)
+    context = config.get_context(config.current_context)
+    assert "server" in config.get_cluster(context["cluster"])
+    with pytest.raises(ValueError):
+        config.get_cluster("foobar")
+    with pytest.raises(ValueError):
+        config.get_cluster("")
+
+
+@pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])
+async def test_get_user(temp_kubeconfig, cls):
+    config = await cls(temp_kubeconfig)
+    context = config.get_context(config.current_context)
+    assert config.get_user(context["user"])
+    with pytest.raises(ValueError):
+        config.get_user("foobar")
+    with pytest.raises(ValueError):
+        config.get_user("")

--- a/kr8s/tests/test_config.py
+++ b/kr8s/tests/test_config.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from kr8s._config import KubeConfig, KubeConfigSet
+
+
+async def test_load_kubeconfig(k8s_cluster):
+    path = str(k8s_cluster.kubeconfig_path)
+    config = await KubeConfig(path)
+    assert config.path == path
+    assert config._raw
+    assert "current-context" in config._raw
+    assert config.current_context
+    assert len(config.clusters) > 0
+    assert "name" in config.clusters[0]
+    assert len(config.users) > 0
+    assert len(config.contexts) > 0
+
+
+async def test_load_kubeconfig_set(k8s_cluster):
+    path = str(k8s_cluster.kubeconfig_path)
+    configs = await KubeConfigSet(path)
+    assert len(configs._configs) == 1
+    assert configs._configs[0].path == path
+    assert configs._configs[0]._raw
+    assert "current-context" in configs._configs[0]._raw
+    assert configs.current_context
+    assert len(configs.clusters) > 0
+    assert "name" in configs.clusters[0]
+    assert len(configs.users) > 0
+    assert len(configs.contexts) > 0


### PR DESCRIPTION
Added support for multiple configuration files set like `KUBECONFIG=/path/to/config1:/path/to/config2`.

Took the opportunity to add new `kr8s._config.KubeConfig` and `kr8s._config.KubeConfigSet` abstractions to handle loading and writing to multiple kubeconfig files. This will be useful later for things like #125 where we need to write back to config files.

These classes are inspired by `kubectl config` but I only implemented enough to get the existing auth working for now, see the TODOs in the file. Will open an issue to track adding other functionality.