### PR TITLE
Remove duplicate clusters/users/contexts when using multiple configs

### DIFF
--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -5,6 +5,8 @@ from typing import Dict, List
 import anyio
 import yaml
 
+from kr8s._data_utils import dict_list_pack, list_dict_unpack
+
 # TODO Implement set
 # TODO Implement unset
 # TODO Implement set cluster
@@ -116,15 +118,27 @@ class KubeConfigSet(object):
 
     @property
     def clusters(self) -> List[Dict]:
-        return [cluster for config in self._configs for cluster in config.clusters]
+        clusters = [cluster for config in self._configs for cluster in config.clusters]
+        # Unpack and repack to remove duplicates
+        clusters = list_dict_unpack(clusters, "name", "cluster")
+        clusters = dict_list_pack(clusters, "name", "cluster")
+        return clusters
 
     @property
     def users(self) -> List[Dict]:
-        return [user for config in self._configs for user in config.users]
+        users = [user for config in self._configs for user in config.users]
+        # Unpack and repack to remove duplicates
+        users = list_dict_unpack(users, "name", "user")
+        users = dict_list_pack(users, "name", "user")
+        return users
 
     @property
     def contexts(self) -> List[Dict]:
-        return [context for config in self._configs for context in config.contexts]
+        contexts = [context for config in self._configs for context in config.contexts]
+        # Unpack and repack to remove duplicates
+        contexts = list_dict_unpack(contexts, "name", "context")
+        contexts = dict_list_pack(contexts, "name", "context")
+        return contexts
 
     @property
     def extensions(self) -> List[Dict]:

--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -26,6 +26,28 @@ def list_dict_unpack(
     return {i[key]: i[value] for i in input_list}
 
 
+def dict_list_pack(
+    input_dict: Dict, key: str = "key", value: str = "value"
+) -> List[Dict]:
+    """Convert a dictionary to a list of dictionaries.
+
+    Parameters
+    ----------
+    input_dict : Dict
+        The dictionary to convert to a list of dictionaries.
+    key : str, optional
+        The key to use for the input dictionary's keys. Defaults to "key".
+    value : str, optional
+        The key to use for the input dictionary's values. Defaults to "value".
+
+    Returns
+    -------
+    List[Dict]
+        A list of dictionaries with the keys and values from the input dictionary.
+    """
+    return [{key: k, value: v} for k, v in input_dict.items()]
+
+
 def dot_to_nested_dict(dot_notated_key: str, value: Any) -> Dict:
     """Convert a dot notated key to a nested dictionary.
 

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -3,6 +3,7 @@
 import pytest
 
 from kr8s._data_utils import (
+    dict_list_pack,
     dict_to_selector,
     dot_to_nested_dict,
     list_dict_unpack,
@@ -13,6 +14,31 @@ from kr8s._data_utils import (
 def test_list_dict_unpack():
     data = [{"key": "hello", "value": "world"}]
     assert list_dict_unpack(data) == {"hello": "world"}
+
+
+def test_dict_list_pack():
+    data = {"hello": "world"}
+    assert dict_list_pack(data) == [{"key": "hello", "value": "world"}]
+
+
+def test_pack_unpack():
+    data = [{"key": "hello", "value": "world"}]
+    assert dict_list_pack(list_dict_unpack(data)) == data
+
+    data = {"hello": "world"}
+    assert list_dict_unpack(dict_list_pack(data)) == data
+
+
+def test_unpack_pack_deduplicate():
+    data = [
+        {"key": "hello", "value": "world"},
+        {"key": "hello", "value": "there"},
+    ]
+    unpacked = list_dict_unpack(data)
+    assert unpacked["hello"] == "there"
+    repacked = dict_list_pack(unpacked)
+    assert len(repacked) == 1
+    assert repacked == [{"key": "hello", "value": "there"}]
 
 
 def test_dot_to_nested_dict():


### PR DESCRIPTION
Multiple configs with the same cluster/user/context name just get appended. This PR removes duplicates.