### PR TITLE
Add Release Drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@ categories:
     label: "ci"
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
-change-title-escapes: "\<*_&" # You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 
 template: |
   ## Changes

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,23 @@
+# These will be overridden by the publish workflow and set to the new tag
+name-template: "Next Release"
+tag-template: "next"
+
+exclude-labels:
+  - kubectl-ng
+categories:
+  - title: "Enhancements"
+    label: "enhancement"
+  - title: "Bug Fixes"
+    label: "bug"
+  - title: "Documentation"
+    label: "documentation"
+  - title: "Project Hygiene"
+    label: "ci"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: "\<*_&" # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+template: |
+  ## Changes
+
+  $CHANGES  

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  if: github.repository == 'kr8s-org/kr8s'
+  update_release_draft:
+    permissions:
+      # Write permission is required to create a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,33 @@
+name: Release Publisher
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish_release:
+    if: github.repository == 'kr8s-org/kr8s'
+    permissions:
+      # Write permission is required to publish a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version env
+        # Use a little bit of bash to extract the tag name from the GitHub ref
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+          # Override the Release name/tag/version with the actual tag name
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          # Publish the Release
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Automatically draft a release on PR merge to main. 
- Automatically publish release when a new tag is pushed.

For more information and reasoning see https://jacobtomlinson.dev/posts/2024/creating-github-releases-automatically-on-tags/