### PR TITLE
Fix kubeconfig with no clusters

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -108,6 +108,14 @@ class KubeAuth:
             self._context = self.kubeconfig.contexts[0]["context"]
             self.active_context = self.kubeconfig.contexts[0]["name"]
 
+        # Load configuration options from the context
+        if self.namespace is None:
+            self.namespace = self.kubeconfig.current_namespace
+
+        # If no cluster is found in the context, assume it's a service account
+        if not self._context["cluster"]:
+            return
+
         self._cluster = self.kubeconfig.get_cluster(self._context["cluster"])
         self._user = self.kubeconfig.get_user(self._context["user"])
         self.server = self._cluster["server"]
@@ -205,8 +213,6 @@ class KubeAuth:
                 "username/password authentication was removed in Kubernetes 1.19, "
                 "kr8s doesn't not support this Kubernetes version"
             )
-        if self.namespace is None:
-            self.namespace = self.kubeconfig.current_namespace
         if "auth-provider" in self._user:
             if p := self._user["auth-provider"]["name"] != "oidc":
                 raise ValueError(

--- a/kr8s/tests/test_config.py
+++ b/kr8s/tests/test_config.py
@@ -3,6 +3,7 @@
 from tempfile import NamedTemporaryFile
 
 import pytest
+import yaml
 
 from kr8s._config import KubeConfig, KubeConfigSet
 
@@ -41,6 +42,14 @@ async def test_load_kubeconfig_set(temp_kubeconfig):
     assert "name" in configs.clusters[0]
     assert len(configs.users) > 0
     assert len(configs.contexts) > 0
+
+
+@pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])
+async def test_kubeconfig_from_dict(temp_kubeconfig, cls):
+    with open(temp_kubeconfig) as fh:
+        config = yaml.safe_load(fh)
+    kubeconfig = await cls(config)
+    assert kubeconfig.raw == config
 
 
 @pytest.mark.parametrize("cls", [KubeConfig, KubeConfigSet])


### PR DESCRIPTION
Closes #358 

In cases where you are using a service account for authentication there may still be a kubeconfig file containing other configuration items. The example in #358 shows using the kubeconfig to store the default namespace. 

In these cases the list of clusters in the kubeconfig is `None`. This PR updates the config to handle that situation. Config objects correctly report `None` when there are no clusters, but it is still possible to read the namespace from the config.

The auth module has then been updated to load the namespace from the config and then fall back to service account authentication.

I also took this opportunity to update `KubeConfig` and `KubeConfigSet` to accept dicts instead of paths for programatically creating a kubeconfig as this was useful when writing the tests. This partially implements #357.