### PR TITLE
Accept kubeconfig as a dict

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import copy
 import json
 import ssl
 import threading
@@ -64,7 +65,8 @@ class Api(object):
         thread_loop_id = f"{thread_id}.{loop_id}"
         if thread_loop_id not in Api._instances:
             Api._instances[thread_loop_id] = weakref.WeakValueDictionary()
-        Api._instances[thread_loop_id][frozenset(kwargs.items())] = self
+        key = hash_kwargs(kwargs)
+        Api._instances[thread_loop_id][key] = self
 
     def __await__(self):
         async def f():
@@ -508,3 +510,11 @@ class Api(object):
     @namespace.setter
     def namespace(self, value):
         self.auth.namespace = value
+
+
+def hash_kwargs(kwargs: dict):
+    key_kwargs = copy.copy(kwargs)
+    for key in key_kwargs:
+        if isinstance(key_kwargs[key], dict):
+            key_kwargs[key] = json.dumps(key_kwargs[key])
+    return frozenset(key_kwargs.items())

--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+import pathlib
 from typing import Dict, List, Union
 
 import anyio
@@ -19,7 +20,9 @@ from kr8s._data_utils import dict_list_pack, list_dict_unpack
 
 class KubeConfigSet(object):
     def __init__(self, *paths_or_dicts: Union[List[str], List[Dict]]):
-        if isinstance(paths_or_dicts[0], str):
+        if isinstance(paths_or_dicts[0], str) or isinstance(
+            paths_or_dicts[0], pathlib.Path
+        ):
             self._configs = [KubeConfig(path) for path in paths_or_dicts]
         else:
             self._configs = [KubeConfig(config) for config in paths_or_dicts]
@@ -177,7 +180,7 @@ class KubeConfig(object):
     def __init__(self, path_or_config: Union[str, Dict]):
         self.path = None
         self._raw = None
-        if isinstance(path_or_config, str):
+        if isinstance(path_or_config, str) or isinstance(path_or_config, pathlib.Path):
             self.path = path_or_config
         else:
             self._raw = path_or_config

--- a/kr8s/asyncio/_api.py
+++ b/kr8s/asyncio/_api.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 
 from kr8s._api import Api as _AsyncApi
+from kr8s._api import hash_kwargs
 
 
 async def api(
@@ -52,7 +53,7 @@ async def api(
         _cls = _SyncApi
 
     async def _f(**kwargs):
-        key = frozenset(kwargs.items())
+        key = hash_kwargs(kwargs)
         thread_id = threading.get_ident()
         try:
             loop_id = id(asyncio.get_running_loop())

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -108,6 +108,14 @@ async def test_kubeconfig_dict(k8s_cluster):
     assert await api.whoami() == "kubernetes-admin"
 
 
+def test_kubeconfig_dict_sync(k8s_cluster):
+    config = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
+    assert isinstance(config, dict)
+    api = kr8s.api(kubeconfig=config)
+    assert api.get("pods", namespace=kr8s.ALL)
+    assert api.whoami() == "kubernetes-admin"
+
+
 async def test_kubeconfig_context(kubeconfig_with_second_context):
     kubeconfig_path, context_name = kubeconfig_with_second_context
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_path, context=context_name)

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -100,6 +100,14 @@ async def test_kubeconfig(k8s_cluster):
     assert await api.whoami() == "kubernetes-admin"
 
 
+async def test_kubeconfig_dict(k8s_cluster):
+    config = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
+    assert isinstance(config, dict)
+    api = await kr8s.asyncio.api(kubeconfig=config)
+    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await api.whoami() == "kubernetes-admin"
+
+
 async def test_kubeconfig_context(kubeconfig_with_second_context):
     kubeconfig_path, context_name = kubeconfig_with_second_context
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_path, context=context_name)


### PR DESCRIPTION
Allow kubeconfig to be passed directly as a `dict` as well as a `str` path.

```python
import kr8s

# Kube config stored in a dictionary
kubeconfig = {
    'apiVersion': 'v1',
    'kind': 'Config',
    'current-context': 'kind-pytest-kind',
    'clusters': [{'cluster': {'certificate-authority-data': ..., 'server': 'https://127.0.0.1:34993'}, 'name': 'kind-pytest-kind'}],
    'contexts': [{'context': {'cluster': 'kind-pytest-kind', 'user': 'kind-pytest-kind', 'namespace': 'kube-system'}, 'name': 'kind-pytest-kind'}],
    'users': [{'name': 'kind-pytest-kind', 'user': {'client-certificate-data': ..., 'client-key-data': ...}}],
    'preferences': {}
}

# Create an API object from the config
api = kr8s.api(kubeconfig=kubeconfig)

# Use the API
print(api.get("pods"))
```

Closes #357 