### PR TITLE
Add project.urls section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ docs = [
     "sphinx-autoapi>=2.1.0",
 ]
 
+[project.urls]
+Documentation = "https://docs.kr8s.org/en/stable"
+Repository = "https://github.com/kr8s-org/kr8s.git"
+Issues = "https://github.com/kr8s-org/kr8s/issues"
+Changelog = "https://github.com/kr8s-org/kr8s/releases"
+
 [tool.pytest.ini_options]
 addopts = "-v --keep-cluster --durations=10 --cov=kr8s --cov-report term-missing --cov-report xml:coverage.xml"
 timeout = 300


### PR DESCRIPTION
Hi :wave:

I submit a PR to add an `project.urls` section to the `pyproject.toml`.

This simplifies the project discovery from PyPI.

> Reference: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
