### PR TITLE
Disable multi-config support on Windows

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -95,13 +95,16 @@ class KubeAuth:
         if isinstance(self._kubeconfig_path_or_dict, str) or isinstance(
             self._kubeconfig_path_or_dict, pathlib.Path
         ):
-            if os.name != "nt":
-                self.kubeconfig = await KubeConfigSet(
-                    *str(self._kubeconfig_path_or_dict).split(":")
-                )
-            else:
-                # Windows doesn't support multiple configs in a path
-                self.kubeconfig = await KubeConfigSet(self._kubeconfig_path_or_dict)
+            try:
+                if os.name != "nt":
+                    self.kubeconfig = await KubeConfigSet(
+                        *str(self._kubeconfig_path_or_dict).split(":")
+                    )
+                else:
+                    # Windows doesn't support multiple configs in a path
+                    self.kubeconfig = await KubeConfigSet(self._kubeconfig_path_or_dict)
+            except ValueError:
+                return
         else:
             self.kubeconfig = await KubeConfigSet(self._kubeconfig_path_or_dict)
         if self._use_context:

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -95,14 +95,13 @@ class KubeAuth:
         if isinstance(self._kubeconfig_path_or_dict, str) or isinstance(
             self._kubeconfig_path_or_dict, pathlib.Path
         ):
-            self._kubeconfig_path_or_dict = os.path.expanduser(
-                self._kubeconfig_path_or_dict
-            )
-            if not os.path.exists(self._kubeconfig_path_or_dict):
-                return
-            self.kubeconfig = await KubeConfigSet(
-                *self._kubeconfig_path_or_dict.split(":")
-            )
+            if os.name != "nt":
+                self.kubeconfig = await KubeConfigSet(
+                    *str(self._kubeconfig_path_or_dict).split(":")
+                )
+            else:
+                # Windows doesn't support multiple configs in a path
+                self.kubeconfig = await KubeConfigSet(self._kubeconfig_path_or_dict)
         else:
             self.kubeconfig = await KubeConfigSet(self._kubeconfig_path_or_dict)
         if self._use_context:

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -100,6 +100,14 @@ async def test_kubeconfig(k8s_cluster):
     assert await api.whoami() == "kubernetes-admin"
 
 
+async def test_kubeconfig_multi(k8s_cluster):
+    api = await kr8s.asyncio.api(
+        kubeconfig=f"{k8s_cluster.kubeconfig_path}:{k8s_cluster.kubeconfig_path}"
+    )
+    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await api.whoami() == "kubernetes-admin"
+
+
 async def test_kubeconfig_dict(k8s_cluster):
     config = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
     assert isinstance(config, dict)

--- a/kr8s/tests/test_config.py
+++ b/kr8s/tests/test_config.py
@@ -21,7 +21,7 @@ def temp_kubeconfig(k8s_cluster):
 
 async def test_load_kubeconfig(temp_kubeconfig):
     config = await KubeConfig(temp_kubeconfig)
-    assert config.path == temp_kubeconfig
+    assert str(config.path) == temp_kubeconfig
     assert config._raw
     assert "current-context" in config._raw
     assert config.current_context
@@ -34,7 +34,7 @@ async def test_load_kubeconfig(temp_kubeconfig):
 async def test_load_kubeconfig_set(temp_kubeconfig):
     configs = await KubeConfigSet(temp_kubeconfig)
     assert len(configs._configs) == 1
-    assert configs._configs[0].path == temp_kubeconfig
+    assert str(configs._configs[0].path) == temp_kubeconfig
     assert configs._configs[0]._raw
     assert "current-context" in configs._configs[0]._raw
     assert configs.current_context


### PR DESCRIPTION
Closes #365 

Added a check for Windows and skip splitting the path.

Also added a test which highlighted another bug where we were prematurely expanding the user path and checking if the file exists.