### PR TITLE
Bump minimum httpx-ws to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",
     "httpx>=0.24.1",
-    "httpx-ws>=0.5.1",
+    "httpx-ws>=0.5.2",
     "python-box>=7.0.1",
 ]
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #370 

`httpx-ws==0.5.1` raises an error with `anyio<4`. In `httpx-ws==0.5.2` they added a lower bound of `anyio>=4` to resolve this. So bumping to `httpx-ws>=0.5.2` here to pick up that new constraint.