### PR TITLE
Add support for tls-server-name arguments in the kubeconfig

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -128,6 +128,8 @@ class Api(object):
             await self._create_session()
         url = self._construct_url(version, base, namespace, url)
         kwargs.update(url=url, method=method)
+        if self.auth.tls_server_name:
+            kwargs["extensions"] = {"sni_hostname": self.auth.tls_server_name}
         auth_attempts = 0
         ssl_attempts = 0
         while True:
@@ -191,6 +193,8 @@ class Api(object):
             await self._create_session()
         url = self._construct_url(version, base, namespace, url)
         kwargs.update(url=url)
+        if self.auth.tls_server_name:
+            kwargs["extensions"] = {"sni_hostname": self.auth.tls_server_name}
         auth_attempts = 0
         while True:
             try:

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -32,6 +32,7 @@ class KubeAuth:
         self.namespace = namespace
         self.active_context = None
         self.kubeconfig: KubeConfigSet = None
+        self.tls_server_name = None
         self._url = url
         self._insecure_skip_tls_verify = False
         self._use_context = context
@@ -137,6 +138,9 @@ class KubeAuth:
             and self._cluster["insecure-skip-tls-verify"]
         ):
             self._insecure_skip_tls_verify = True
+
+        if "tls-server-name" in self._cluster:
+            self.tls_server_name = self._cluster["tls-server-name"]
 
         if "exec" in self._user:
             if (


### PR DESCRIPTION
Currently the kr8s module doesn't honor the [tls-server-name](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#Cluster) argument of the cluster in the kubeconfig.

This PR add supports for the tls-server-name by leveraging the `sni_hostname` extension of httpx. 