### PR TITLE
Handle empty KUBECONFIG path item gracefully when other valid paths

### DIFF
--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
-import os
 import pathlib
 from typing import Dict, List, Union
 
@@ -190,7 +189,7 @@ class KubeConfig(object):
             self.path = pathlib.Path(path_or_config).expanduser()
             if not self.path.exists():
                 raise ValueError(f"File {self.path} does not exist")
-            if os.path.isdir(self.path):
+            if self.path.is_dir():
                 raise IsADirectoryError(
                     f'Error loading config file "{self.path}": is a directory.'
                 )

--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+import os
 import pathlib
 from typing import Dict, List, Union
 
@@ -182,10 +183,17 @@ class KubeConfig(object):
     def __init__(self, path_or_config: Union[str, Dict]):
         self.path = None
         self._raw = None
+
+        if not path_or_config:
+            raise ValueError("KubeConfig path_or_config is None or empty string.")
         if isinstance(path_or_config, str) or isinstance(path_or_config, pathlib.Path):
             self.path = pathlib.Path(path_or_config).expanduser()
             if not self.path.exists():
                 raise ValueError(f"File {self.path} does not exist")
+            if os.path.isdir(self.path):
+                raise IsADirectoryError(
+                    f'Error loading config file "{self.path}": is a directory.'
+                )
         else:
             self._raw = path_or_config
 

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -177,6 +177,21 @@ def test_no_config():
         kr8s.api(kubeconfig="/no/file/here")
 
 
+def test_kubeconfig_multi_paths(k8s_cluster, tmp_path):
+    kubeconfig1: Path = k8s_cluster.kubeconfig_path
+    kubeconfig2 = Path(tmp_path / "kubeconfig").write_bytes(kubeconfig1.read_bytes())
+    kubeconfig_multi_str = f"{kubeconfig1}:{kubeconfig2}"
+    api = kr8s.api(kubeconfig=kubeconfig_multi_str)
+    assert (
+        str(api.auth._serviceaccount) == "/var/run/secrets/kubernetes.io/serviceaccount"
+    )
+
+
+def test_kubeconfig_isdir_fail(tmp_path):
+    with pytest.raises(IsADirectoryError):
+        kr8s.api(kubeconfig=tmp_path)
+
+
 async def test_service_account(serviceaccount):
     api = await kr8s.asyncio.api(
         serviceaccount=serviceaccount, kubeconfig="/no/file/here"


### PR DESCRIPTION
fixes #369 

Changes:
- Update `KubeConfig.__init__`:
  - raise `ValueError` if empty string or None provided
  - raise `IsDirectoryError` if path provided is a directory. Error message similar to kubectl