### PR TITLE
Fix `kubectl-ng api-resources` client usage

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_api_resources.py
+++ b/examples/kubectl-ng/kubectl_ng/_api_resources.py
@@ -68,7 +68,7 @@ async def api_resources(
         kubectl-ng api-resources --api-group=rbac.authorization.k8s.io
 
     """
-    kubernetes = kr8s.api()
+    kubernetes = await kr8s.asyncio.api()
     categories = [c.strip() for c in categories.split(",")] if categories else None
     verbs = [v.strip() for v in verbs.split(",")] if verbs else None
 

--- a/examples/kubectl-ng/kubectl_ng/tests/test_kng_api_resources.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_kng_api_resources.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from kubectl_ng.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_api_resources():
+    result = runner.invoke(app, ["api-resources"])
+    assert result.exit_code == 0
+    assert "pod" in result.stdout


### PR DESCRIPTION
`kubectl-ng api-resources` was using the sync client but then awaiting it's methods. This PR switches it to the async client and adds a test to avoid this regression again.