### PR TITLE
Rename async utilities and add more docstrings

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -6,6 +6,8 @@ import kr8s.objects  # noqa
 
 from ._api import ALL  # noqa
 from ._api import Api as _AsyncApi
+from ._async_utils import run_sync as _run_sync
+from ._async_utils import sync as _sync  # noqa
 from ._exceptions import (
     APITimeoutError,  # noqa
     ConnectionClosedError,  # noqa
@@ -13,8 +15,6 @@ from ._exceptions import (
     NotFoundError,  # noqa
     ServerError,  # noqa
 )
-from ._io import run_sync as _run_sync
-from ._io import sync as _sync  # noqa
 from .asyncio import (
     api as _api,
 )

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -9,8 +9,8 @@ import ssl
 
 import anyio
 
+from ._async_utils import NamedTemporaryFile, check_output
 from ._config import KubeConfigSet
-from ._io import NamedTemporaryFile, check_output
 
 
 class KubeAuth:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -29,6 +29,7 @@ from box import Box
 import kr8s
 import kr8s.asyncio
 from kr8s._api import Api
+from kr8s._async_utils import sync
 from kr8s._data_utils import (
     dict_to_selector,
     dot_to_nested_dict,
@@ -37,7 +38,6 @@ from kr8s._data_utils import (
 )
 from kr8s._exceptions import NotFoundError, ServerError
 from kr8s._exec import Exec
-from kr8s._io import sync
 from kr8s.asyncio.portforward import PortForward as AsyncPortForward
 from kr8s.portforward import PortForward as SyncPortForward
 

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from functools import partial
 
-from ._io import run_sync, sync
+from ._async_utils import run_sync, sync
 from ._objects import (
     APIObject as _APIObject,
 )

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -3,7 +3,7 @@
 import threading
 import time
 
-from ._io import sync
+from ._async_utils import sync
 from ._portforward import PortForward as _PortForward
 
 

--- a/kr8s/tests/test_io.py
+++ b/kr8s/tests/test_io.py
@@ -5,7 +5,7 @@ import pytest
 import trio
 
 import kr8s
-from kr8s._io import NamedTemporaryFile
+from kr8s._async_utils import NamedTemporaryFile
 from kr8s.asyncio.objects import Pod
 
 
@@ -62,8 +62,8 @@ async def test_tempfiles():
 
 
 async def test_check_output():
-    output = await kr8s._io.check_output("echo", "hello")
+    output = await kr8s._async_utils.check_output("echo", "hello")
     assert output == "hello\n"
 
     with pytest.raises(RuntimeError, match="non-zero code"):
-        await kr8s._io.check_output("false")
+        await kr8s._async_utils.check_output("false")


### PR DESCRIPTION
In #85 the private async utility code got renamed from `_asyncio` to `_io` as a reaction to adding `trio` support. However that name leaves a lot to be desired, so this PR renames it again to `_async_utils` to try and more clearly describe what it does.

I also took the opportunity to add a bunch more docstrings to try and make it clearer what the module does and the reasoning behind it.