### PR TITLE
Refactor kubectl-ng get to allow --watch flag

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -2,10 +2,12 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from typing import List
 
+import anyio
 import rich.table
 import typer
 from rich import box
 from rich.console import Console
+from rich.live import Live
 
 import kr8s
 from kr8s.asyncio.objects import Table
@@ -13,6 +15,47 @@ from kr8s.asyncio.objects import Table
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 console = Console()
+
+
+async def draw_table(kind, response, resource_names):
+    table = rich.table.Table(box=box.SIMPLE)
+    table.add_column("Namespace", style="magenta", no_wrap=True)
+
+    for column in response.column_definitions:
+        if column["priority"] == 0:
+            kwargs = {}
+            if column["name"] == "Name":
+                kwargs = {"style": "cyan", "no_wrap": True}
+            table.add_column(column["name"], **kwargs)
+
+    for row in response.rows:
+        if not resource_names or row["object"]["metadata"]["name"] == resource_names[0]:
+            r = [
+                str(row)
+                for row, column in zip(row["cells"], response.column_definitions)
+                if column["priority"] == 0
+            ]
+            table.add_row(row["object"]["metadata"]["namespace"], *r)
+
+    if not table.rows:
+        if resource_names:
+            console.print(f"No resources found with name {resource_names[0]}.")
+        else:
+            console.print(f"No {kind} resources found in current namespace.")
+        return None
+    return table
+
+
+async def get_resources(resources, label_selector, field_selector):
+    data = {}
+    for kind in resources:
+        data[kind] = await kr8s.asyncio.get(
+            kind,
+            label_selector=label_selector,
+            field_selector=field_selector,
+            as_object=Table,
+        )
+    return data
 
 
 async def get(
@@ -63,6 +106,12 @@ async def get(
         "Names are case-sensitive. "
         "You can also use multiple flag options like -L label1 -L label2...",
     ),
+    watch: bool = typer.Option(
+        False,
+        "-w",
+        "--watch",
+        help="After listing/getting the requested object, watch for changes.",
+    ),
 ):
     """Display one or many resources.
 
@@ -79,6 +128,8 @@ async def get(
     # Support kubectl-ng get pod,svc
     if len(resources) == 1:
         resources = resources[0].split(",")
+        if len(resources) > 1 and watch:
+            raise typer.BadParameter("you may only specify a single resource type")
     # Support kubectl-ng get pod [name]
     elif len(resources) == 2:
         resources, resource_names = [[r] for r in resources]
@@ -91,43 +142,19 @@ async def get(
         kubernetes.namespace = namespace
     if all_namespaces:
         kubernetes.namespace = kr8s.ALL
-    for kind in resources:
-        response = await kubernetes.get(
-            kind,
-            label_selector=label_selector,
-            field_selector=field_selector,
-            as_object=Table,
-        )
 
-        table = rich.table.Table(box=box.SIMPLE)
-        table.add_column("Namespace", style="magenta", no_wrap=True)
-
-        for column in response.column_definitions:
-            if column["priority"] == 0:
-                kwargs = {}
-                if column["name"] == "Name":
-                    kwargs = {"style": "cyan", "no_wrap": True}
-                table.add_column(column["name"], **kwargs)
-
-        for row in response.rows:
-            if (
-                not resource_names
-                or row["object"]["metadata"]["name"] == resource_names[0]
-            ):
-                r = [
-                    str(row)
-                    for row, column in zip(row["cells"], response.column_definitions)
-                    if column["priority"] == 0
-                ]
-                table.add_row(row["object"]["metadata"]["namespace"], *r)
-
-        if not table.rows:
-            if resource_names:
-                console.print(f"No resources found with name {resource_names[0]}.")
-            else:
-                console.print(
-                    f"No {kind} resources found in {kubernetes.namespace} namespace."
-                )
-            return
-
+    data = await get_resources(resources, label_selector, field_selector)
+    for kind, response in data.items():
+        table = await draw_table(kind, response, resource_names)
+    if not watch:
         console.print(table)
+    else:
+        with Live(table, console=console, auto_refresh=False) as live:
+            while True:
+                await anyio.sleep(5)
+                data = await get_resources(resources, label_selector, field_selector)
+                # TODO handle changes in resources
+                for kind, response in data.items():
+                    table = await draw_table(kind, response, resource_names)
+                live.update(table)
+                live.refresh()

--- a/examples/kubectl-ng/kubectl_ng/_typer_utils.py
+++ b/examples/kubectl-ng/kubectl_ng/_typer_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 
 import asyncio
+from contextlib import suppress
 from functools import wraps
 
 import typer
@@ -10,7 +11,8 @@ import typer
 def _typer_async(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        return asyncio.run(f(*args, **kwargs))
+        with suppress(asyncio.CancelledError, KeyboardInterrupt):
+            return asyncio.run(f(*args, **kwargs))
 
     return wrapper
 

--- a/examples/kubectl-ng/kubectl_ng/tests/test_kng_get.py
+++ b/examples/kubectl-ng/kubectl_ng/tests/test_kng_get.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from kubectl_ng.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_get_pods():
+    result = runner.invoke(app, ["get", "pods", "-A"])
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR starts to break out getting the list of resources and rendering the list of resources into separate pieces. This allows us to add the `--watch` flag where we can call these new functions repeatedly to update the view of resources.

Ultimately I want to compare incoming data with current data and add little markers or change highlighting to show when information is changing, similar to what `k9s` does. But I'll add that in a follow up PR.