### PR TITLE
Allow passing custom plural suffix to `new_class()`

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1609,6 +1609,7 @@ def new_class(
     namespaced=True,
     scalable: Optional[bool] = None,
     scalable_spec: Optional[str] = None,
+    plural_suffix: str = "s",
 ) -> Type[APIObject]:
     """Create a new APIObject subclass.
 
@@ -1617,6 +1618,9 @@ def new_class(
         version: The Kubernetes API version.
         asyncio: Whether to use asyncio or not.
         namespaced: Whether the resource is namespaced or not.
+        scalable: Whether the resource is scalable or not.
+        scalable_spec: The name of the field to use for scaling.
+        plural_suffix: The suffix to use for the plural form of the resource.
 
     Returns:
         A new APIObject subclass.
@@ -1632,8 +1636,8 @@ def new_class(
             "kind": kind,
             "version": version,
             "_asyncio": asyncio,
-            "endpoint": kind.lower() + "s",
-            "plural": kind.lower() + "s",
+            "endpoint": kind.lower() + plural_suffix,
+            "plural": kind.lower() + plural_suffix,
             "singular": kind.lower(),
             "namespaced": namespaced,
             "scalable": scalable or False,

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -977,3 +977,15 @@ def test_sync_new_class_is_sync():
     instance = MyResource({})
     assert not instance._asyncio
     assert not inspect.iscoroutinefunction(instance.create)
+
+
+def test_new_class_plural_suffix():
+    MyPlural = new_class(
+        kind="MyPlural",
+        version="newclass.example.com/v1",
+        namespaced=True,
+        plural_suffix="es",
+    )
+    instance = MyPlural({})
+    assert instance.plural.endswith("es")
+    assert instance.endpoint.endswith("es")


### PR DESCRIPTION
Closes #391 

Add keyword argument to allow overriding the plural suffix.

```python
from kr8s.objects import new_class

EC2NodeClass = new_class(
    kind="EC2NodeClass",
    version="karpenter.k8s.aws/v1beta1",
    namespaced=False,
    plural_suffix="es",
)
```