### PR TITLE
Allow Release Drafter to be run manually

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,7 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Before making a release I sometimes want to tweak the titles and labels on merged PRs and it would be nice to easily update the draft release with the changes. This adds the workflow dispatch option to the drafter workflow.