### PR TITLE
Change async default in object utils depending on import path

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1669,7 +1669,7 @@ def object_from_spec(
         cls = get_class(spec["kind"], spec["apiVersion"], _asyncio=_asyncio)
     except KeyError:
         if allow_unknown_type:
-            cls = new_class(spec["kind"], spec["apiVersion"])
+            cls = new_class(spec["kind"], spec["apiVersion"], asyncio=_asyncio)
         else:
             raise
     return cls(spec, api=api)

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -39,4 +39,7 @@ from kr8s._objects import (  # noqa
     Table,
     object_from_name_type,
     objects_from_files,
+    get_class,
+    new_class,
+    object_from_spec,
 )

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -111,8 +111,18 @@ from ._objects import (
 from ._objects import (
     Table as _Table,
 )
-from ._objects import get_class, new_class, object_from_spec  # noqa
+from ._objects import (
+    get_class as _get_class,
+)
+from ._objects import (
+    new_class as _new_class,
+)
+
+# noqa
 from ._objects import object_from_name_type as _object_from_name_type
+from ._objects import (
+    object_from_spec as _object_from_spec,
+)
 from ._objects import objects_from_files as _objects_from_files
 
 
@@ -334,3 +344,6 @@ class Table(_Table):
 
 object_from_name_type = run_sync(partial(_object_from_name_type, _asyncio=False))
 objects_from_files = run_sync(partial(_objects_from_files, _asyncio=False))
+get_class = partial(_get_class, _asyncio=False)
+new_class = partial(_new_class, asyncio=False)
+object_from_spec = partial(_object_from_spec, _asyncio=False)

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -562,6 +562,34 @@ async def test_new_sync_class_registration():
     assert not MyOtherSyncResource._asyncio
 
 
+async def test_new_class_registration_from_spec():
+    my_async_resource_instance = object_from_spec(
+        {
+            "kind": "MyAsyncResource",
+            "apiVersion": "foo.kr8s.org/v1alpha1",
+            "metadata": {"name": "foo"},
+            "spec": {},
+        },
+        allow_unknown_type=True,
+    )  # noqa: F841
+
+    assert my_async_resource_instance._asyncio
+
+
+async def test_new_sync_class_registration_from_spec():
+    my_sync_resource_instance = sync_object_from_spec(
+        {
+            "kind": "MySyncResource",
+            "apiVersion": "foo.kr8s.org/v1alpha1",
+            "metadata": {"name": "foo"},
+            "spec": {},
+        },
+        allow_unknown_type=True,
+    )  # noqa: F841
+
+    assert not my_sync_resource_instance._asyncio
+
+
 async def test_deployment_scale(example_deployment_spec):
     deployment = await Deployment(example_deployment_spec)
     await deployment.create()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -563,7 +563,7 @@ async def test_new_sync_class_registration():
 
 
 async def test_new_class_registration_from_spec():
-    my_async_resource_instance = object_from_spec(
+    my_async_resource_instance = await object_from_spec(
         {
             "kind": "MyAsyncResource",
             "apiVersion": "foo.kr8s.org/v1alpha1",

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -21,13 +21,24 @@ from kr8s.asyncio.objects import (
     PersistentVolume,
     Pod,
     Service,
+    get_class,
+    new_class,
     object_from_name_type,
+    object_from_spec,
     objects_from_files,
 )
 from kr8s.asyncio.portforward import PortForward
 from kr8s.objects import Pod as SyncPod
 from kr8s.objects import Service as SyncService
-from kr8s.objects import get_class, new_class, object_from_spec
+from kr8s.objects import (
+    get_class as sync_get_class,
+)
+from kr8s.objects import (
+    new_class as sync_new_class,
+)
+from kr8s.objects import (
+    object_from_spec as sync_object_from_spec,
+)
 from kr8s.objects import objects_from_files as sync_objects_from_files
 
 DEFAULT_TIMEOUT = httpx.Timeout(30)
@@ -491,11 +502,27 @@ async def test_object_from_spec(example_pod_spec, example_service_spec):
     assert isinstance(pod, Pod)
     assert pod.name == example_pod_spec["metadata"]["name"]
     assert pod.spec == example_pod_spec["spec"]
+    assert pod._asyncio
 
     service = object_from_spec(example_service_spec)
     assert isinstance(service, Service)
     assert service.name == example_service_spec["metadata"]["name"]
     assert service.spec == example_service_spec["spec"]
+    assert service._asyncio
+
+
+async def test_object_from_spec_sync(example_pod_spec, example_service_spec):
+    pod = sync_object_from_spec(example_pod_spec)
+    assert isinstance(pod, Pod)
+    assert pod.name == example_pod_spec["metadata"]["name"]
+    assert pod.spec == example_pod_spec["spec"]
+    assert not pod._asyncio
+
+    service = sync_object_from_spec(example_service_spec)
+    assert isinstance(service, Service)
+    assert service.name == example_service_spec["metadata"]["name"]
+    assert service.spec == example_service_spec["spec"]
+    assert not service._asyncio
 
 
 async def test_subclass_registration():
@@ -520,6 +547,19 @@ async def test_new_class_registration():
     MyOtherResource = new_class("MyOtherResource.foo.kr8s.org/v1alpha1")  # noqa: F841
 
     get_class("MyOtherResource", "foo.kr8s.org/v1alpha1")
+    assert MyOtherResource._asyncio
+
+
+async def test_new_sync_class_registration():
+    with pytest.raises(KeyError):
+        sync_get_class("MyOtherSyncResource", "foo.kr8s.org/v1alpha1")
+
+    MyOtherSyncResource = sync_new_class(
+        "MyOtherSyncResource.foo.kr8s.org/v1alpha1"
+    )  # noqa: F841
+
+    sync_get_class("MyOtherSyncResource", "foo.kr8s.org/v1alpha1")
+    assert not MyOtherSyncResource._asyncio
 
 
 async def test_deployment_scale(example_deployment_spec):


### PR DESCRIPTION
Closes #341 

This PR changes the default value of the `asyncio` kwarg for a few utilities and adds an atlernative import location because creating a new class and creating an object from a spec behaved in a surprising way. This change is necessary because the current behaviour is confusing and I see folks accidentally creating async objects and expecting them to be sync.

### Example

**Previously**

Even though we import `new_class` and `object_from_spec` from `kr8s.objects` (which typically holds the sync API) the class or instance that gets created is async, and to make it sync you pass a kwarg.

```python
# Create an async class
from kr8s.objects import new_class
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1")

# Create a sync class
from kr8s.objects import new_class
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1", asyncio=False)
```

**Now**

The new functionality means that we can import `new_class` from `kr8s.asyncio.objects` and it will create an async class by default. Then the default kwarg has been flipped on `kr8s.objects.new_class` to create sync objects.

```python
# Create an async class
from kr8s.asyncio.objects import new_class
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1")

# Create a sync class
from kr8s.objects import new_class
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1")
```

**Backward compatibility**

You can still use the old version by explicitly setting the kwargand it doesn't matter where you import `new_class` from.

```python
from kr8s.objects import new_class
# from kr8s.asyncio.objects import new_class
MyAsyncClass = new_class("MyClass.foo.kr8s.org/v1alpha1", asyncio=True)
MySyncClass = new_class("MyClass.foo.kr8s.org/v1alpha1", asyncio=False)
```

### ⚠️ Breaking change

This will be a breaking change for folks using `kr8s.objects.new_class()` without setting the `asyncio=` kwarg.

```python
from kr8s.objects import new_class

# Before
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1")  # Creates an async class

# After
MyClass = new_class("MyClass.foo.kr8s.org/v1alpha1")  # Creates an sync class
```

### Considerations

I was tempted to make `kr8s.asyncio.objects.new_class()` a coroutine that would need to be awaited, but given that the function performs no IO it didn't make sense to do so.

This also means that `kr8s.asyncio.objects.object_from_spec()` returns an instance of an async class, which needs to be awaited.

```python
from kr8s.asyncio.objects import object_from_spec

obj = await object_from_spec({...})
```

If I had made `object_from_spec` a coroutine then `obj` would need to be awaited again which doesn't make sense.