### PR TITLE
Add a helpful exception when forgetting to await an async class

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -112,7 +112,8 @@ class APIObject:
     def api(self):
         if self._api is None and self._asyncio:
             raise RuntimeError(
-                "Object has not been initialized with an API object. Did you forget to await it?"
+                f"{self.__repr__()} has not been initialized with an API object. "
+                "Did you forget to await it?"
             )
         return self._api
 

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -77,14 +77,14 @@ class APIObject:
             )
         if namespace is not None:
             self._raw["metadata"]["namespace"] = namespace
-        self.api = api
-        if self.api is None and not self._asyncio:
-            self.api = kr8s.api()
+        self._api = api
+        if self._api is None and not self._asyncio:
+            self._api = kr8s.api()
 
     def __await__(self):
         async def f():
-            if self.api is None:
-                self.api = await kr8s.asyncio.api()
+            if self._api is None:
+                self._api = await kr8s.asyncio.api()
             return self
 
         return f().__await__()
@@ -107,6 +107,18 @@ class APIObject:
         if self.namespaced and self.namespace != other.namespace:
             return False
         return True
+
+    @property
+    def api(self):
+        if self._api is None and self._asyncio:
+            raise RuntimeError(
+                "Object has not been initialized with an API object. Did you forget to await it?"
+            )
+        return self._api
+
+    @api.setter
+    def api(self, value):
+        self._api = value
 
     @property
     def raw(self) -> str:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -140,6 +140,13 @@ async def test_pod_wait_ready(example_pod_spec):
     await pod.wait("delete")
 
 
+async def test_pod_missing_await_error(example_pod_spec):
+    pod = Pod(example_pod_spec)  # We intentionally forget to await here
+    assert pod._api is None
+    with pytest.raises(RuntimeError, match="forget to await it"):
+        await pod.create()
+
+
 async def test_pod_wait_multiple_conditions(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()


### PR DESCRIPTION
Adding a little check to ensure that an async object has been correctly awaited.

**Before**

```python
>>> from kr8s.asyncio.objects import Pod
>>> pod = Pod({"metadata": {"name": "foo"}})  # Oops we forgot to await this
>>> await pod.create()
...
AttributeError: 'NoneType' object has no attribute 'call_api'
```

**After**

```python
>>> from kr8s.asyncio.objects import Pod
>>> pod = Pod({"metadata": {"name": "foo"}})  # Oops we forgot to await this
>>> await pod.create()
...
RuntimeError: RuntimeError: <Pod foo> has not been initialized with an API object. Did you forget to await it?
```