### PR TITLE
Ensure `kind` and `apiVersion` are always included in raw specs

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -124,7 +124,9 @@ class APIObject:
     @property
     def raw(self) -> str:
         """Raw object returned from the Kubernetes API."""
-        return self._raw
+        raw_spec = {"kind": self.kind, "apiVersion": self.version}
+        raw_spec.update(self._raw)
+        return raw_spec
 
     @raw.setter
     def raw(self, value: Any) -> None:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -281,6 +281,19 @@ async def test_nonexistant():
         await pod.exists(ensure=True)
 
 
+async def test_pod_kind_api_raw():
+    pod = await Pod(
+        {
+            "metadata": {"name": "foo"},
+            "spec": {"containers": [{"name": "foo", "image": "nginx"}]},
+        }
+    )
+    assert "kind" in pod.raw
+    assert "apiVersion" in pod.raw
+    assert pod.raw["kind"] == "Pod"
+    assert pod.raw["apiVersion"] == "v1"
+
+
 async def test_pod_metadata(example_pod_spec, ns):
     pod = await Pod(example_pod_spec)
     await pod.create()


### PR DESCRIPTION
Closes #400 

It seems that when creating custom resources Kubernetes always validates that the `kind` and `apiVersion` fields are included in the spec. This isn't true for core objects and these values can be omitted and we've always made the assumption that this was true for all objects.

This PR ensures that those fields are always included in the raw spec.