### PR TITLE
Allow explicit passing of plural name to new_class instead of suffix

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1624,7 +1624,7 @@ def new_class(
     namespaced=True,
     scalable: Optional[bool] = None,
     scalable_spec: Optional[str] = None,
-    plural_suffix: str = "s",
+    plural: Optional[str] = None,
 ) -> Type[APIObject]:
     """Create a new APIObject subclass.
 
@@ -1635,7 +1635,7 @@ def new_class(
         namespaced: Whether the resource is namespaced or not.
         scalable: Whether the resource is scalable or not.
         scalable_spec: The name of the field to use for scaling.
-        plural_suffix: The suffix to use for the plural form of the resource.
+        plural: The plural form of the resource.
 
     Returns:
         A new APIObject subclass.
@@ -1644,6 +1644,7 @@ def new_class(
         kind, version = kind.split(".", 1)
     if version is None:
         version = "v1"
+    plural = plural or kind.lower() + "s"
     newcls = type(
         kind,
         (APIObject,),
@@ -1651,8 +1652,8 @@ def new_class(
             "kind": kind,
             "version": version,
             "_asyncio": asyncio,
-            "endpoint": kind.lower() + plural_suffix,
-            "plural": kind.lower() + plural_suffix,
+            "endpoint": plural.lower(),
+            "plural": plural.lower(),
             "singular": kind.lower(),
             "namespaced": namespaced,
             "scalable": scalable or False,

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1068,12 +1068,31 @@ def test_sync_new_class_is_sync():
 
 
 def test_new_class_plural_suffix():
-    MyPlural = new_class(
-        kind="MyPlural",
+    MyFoo = new_class(
+        kind="MyFoo",
         version="newclass.example.com/v1",
         namespaced=True,
-        plural_suffix="es",
     )
-    instance = MyPlural({})
-    assert instance.plural.endswith("es")
-    assert instance.endpoint.endswith("es")
+    instance = MyFoo({})
+    assert instance.plural == "myfoos"
+    assert instance.endpoint == "myfoos"
+
+    MyClass = new_class(
+        kind="MyClass",
+        plural="MyClasses",
+        version="newclass.example.com/v1",
+        namespaced=True,
+    )
+    instance = MyClass({})
+    assert instance.plural == "myclasses"
+    assert instance.endpoint == "myclasses"
+
+    MyPolicy = new_class(
+        kind="MyPolicy",
+        plural="MyPolicies",
+        version="newclass.example.com/v1",
+        namespaced=True,
+    )
+    instance = MyPolicy({})
+    assert instance.plural == "mypolicies"
+    assert instance.endpoint == "mypolicies"


### PR DESCRIPTION
Reverts #392 
Closes #402 

In #392 I added support for specifying the `plural_suffix` in `new_class`. This was done because previously it just assumed the plural form added an `s` suffix (`pod` => `pods`). In #391 an example was given where the suffix should be `es` (`ec2nodeclass` => `ec2nodeclasses`), so I added the ability to modify the suffix.

However since then I found an example where we don't simply add a suffix, but instead replace the last letter with a suffix (`policy` => `policies`).

This PR reverts the ability to modify the suffix and instead gives the ability to specify the entire plural. This makes things less "clever" and hopefully solves other edge cases we haven't thought of yet.

```python
from kr8s.objects import new_class

MyPolicy = new_class(
        kind="MyPolicy",
        plural="MyPolicies",
        version="newclass.example.com/v1",
        namespaced=True,
    )
```

Plural is still optional though, and if you omit it then we just assume the plural form appends an `s` to the singular.

This change is slightly breaking because I opted to replace the `plural_suffix` with just `plural` rather than allow both. But the impact should be low because it is a very new addition and I expect few users will have adopted it.