### PR TITLE
Fix implicit optional types

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from functools import partial, update_wrapper
+from typing import Optional
 
 import kr8s.objects  # noqa
 
@@ -94,11 +95,11 @@ def get(*args, **kwargs):
 
 
 def api(
-    url: str = None,
-    kubeconfig: str = None,
-    serviceaccount: str = None,
-    namespace: str = None,
-    context: str = None,
+    url: Optional[str] = None,
+    kubeconfig: Optional[str] = None,
+    serviceaccount: Optional[str] = None,
+    namespace: Optional[str] = None,
+    context: Optional[str] = None,
 ) -> Api:
     """Create a :class:`kr8s.Api` object for interacting with the Kubernetes API.
 

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -10,7 +10,7 @@ import ssl
 import threading
 import warnings
 import weakref
-from typing import AsyncGenerator, Dict, List, Tuple, Union
+from typing import AsyncGenerator, Dict, List, Optional, Tuple, Union
 
 import httpx
 import httpx_ws
@@ -105,7 +105,7 @@ class Api(object):
         self,
         version: str = "v1",
         base: str = "",
-        namespace: str = None,
+        namespace: Optional[str] = None,
         url: str = "",
     ) -> str:
         if not base:
@@ -129,7 +129,7 @@ class Api(object):
         method: str = "GET",
         version: str = "v1",
         base: str = "",
-        namespace: str = None,
+        namespace: Optional[str] = None,
         url: str = "",
         raise_for_status: bool = True,
         stream: bool = False,
@@ -196,7 +196,7 @@ class Api(object):
         self,
         version: str = "v1",
         base: str = "",
-        namespace: str = None,
+        namespace: Optional[str] = None,
         url: str = "",
         **kwargs,
     ) -> AsyncGenerator[httpx_ws.AsyncWebSocketSession, None]:
@@ -278,10 +278,10 @@ class Api(object):
     async def async_get_kind(
         self,
         kind: Union[str, type],
-        namespace: str = None,
-        label_selector: Union[str, Dict] = None,
-        field_selector: Union[str, Dict] = None,
-        params: dict = None,
+        namespace: Optional[str] = None,
+        label_selector: Optional[Union[str, Dict]] = None,
+        field_selector: Optional[Union[str, Dict]] = None,
+        params: Optional[dict] = None,
         watch: bool = False,
         **kwargs,
     ) -> dict:
@@ -332,10 +332,10 @@ class Api(object):
         self,
         kind: Union[str, type],
         *names: List[str],
-        namespace: str = None,
-        label_selector: Union[str, Dict] = None,
-        field_selector: Union[str, Dict] = None,
-        as_object: object = None,
+        namespace: Optional[str] = None,
+        label_selector: Optional[Union[str, Dict]] = None,
+        field_selector: Optional[Union[str, Dict]] = None,
+        as_object: Optional[object] = None,
         **kwargs,
     ) -> List[object]:
         """
@@ -377,10 +377,10 @@ class Api(object):
         self,
         kind: Union[str, type],
         *names: List[str],
-        namespace: str = None,
-        label_selector: Union[str, Dict] = None,
-        field_selector: Union[str, Dict] = None,
-        as_object: object = None,
+        namespace: Optional[str] = None,
+        label_selector: Optional[Union[str, Dict]] = None,
+        field_selector: Optional[Union[str, Dict]] = None,
+        as_object: Optional[object] = None,
         **kwargs,
     ) -> List[object]:
         headers = {}
@@ -416,10 +416,10 @@ class Api(object):
     async def watch(
         self,
         kind: str,
-        namespace: str = None,
-        label_selector: Union[str, Dict] = None,
-        field_selector: Union[str, Dict] = None,
-        since: str = None,
+        namespace: Optional[str] = None,
+        label_selector: Optional[Union[str, Dict]] = None,
+        field_selector: Optional[Union[str, Dict]] = None,
+        since: Optional[str] = None,
     ):
         """Watch a Kubernetes resource."""
         async for t, object in self.async_watch(
@@ -434,10 +434,10 @@ class Api(object):
     async def async_watch(
         self,
         kind: str,
-        namespace: str = None,
-        label_selector: Union[str, Dict] = None,
-        field_selector: Union[str, Dict] = None,
-        since: str = None,
+        namespace: Optional[str] = None,
+        label_selector: Optional[Union[str, Dict]] = None,
+        field_selector: Optional[Union[str, Dict]] = None,
+        since: Optional[str] = None,
     ) -> Tuple[str, object]:
         """Watch a Kubernetes resource."""
         async with self.async_get_kind(

--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -55,7 +55,7 @@ class KubeConfigSet(KubeConfigMixin, object):
     def path(self) -> str:
         return self.get_path()
 
-    def get_path(self, context: str = None) -> str:
+    def get_path(self, context: Optional[str] = None) -> str:
         """Return the path of the config for the current context.
 
         Args:
@@ -297,7 +297,9 @@ class KubeConfig(KubeConfigMixin, object):
                 return user["user"]
         raise ValueError(f"User {user_name} not found")
 
-    async def set(self, pointer: str, value: Any = None, strict: bool = False) -> dict:
+    async def set(
+        self, pointer: str, value: Optional[Any] = None, strict: bool = False
+    ) -> dict:
         """Replace a value using a JSON Pointer."""
         if strict:
             patch = jsonpath.JSONPatch().replace(pointer, value)

--- a/kr8s/_exec.py
+++ b/kr8s/_exec.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, BinaryIO, List, Union
+from typing import TYPE_CHECKING, BinaryIO, List, Optional, Union
 
 from kr8s._exceptions import ExecError
 
@@ -28,10 +28,10 @@ class Exec:
         self,
         resource: APIObject,
         command: List[str],
-        container: str = None,
-        stdin: Union[str | BinaryIO] = None,
-        stdout: Union[str | BinaryIO] = None,
-        stderr: Union[str | BinaryIO] = None,
+        container: Optional[str] = None,
+        stdin: Optional[Union[str | BinaryIO]] = None,
+        stdout: Optional[Union[str | BinaryIO]] = None,
+        stderr: Optional[Union[str | BinaryIO]] = None,
         check: bool = True,
         capture_output: bool = True,
     ) -> None:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -59,7 +59,9 @@ class APIObject:
     scalable_spec = "replicas"
     _asyncio = True
 
-    def __init__(self, resource: dict, namespace: str = None, api: Api = None) -> None:
+    def __init__(
+        self, resource: dict, namespace: Optional[str] = None, api: Optional[Api] = None
+    ) -> None:
         """Initialize an APIObject."""
         with contextlib.suppress(TypeError, ValueError):
             resource = dict(resource)
@@ -196,11 +198,11 @@ class APIObject:
     @classmethod
     async def get(
         cls,
-        name: str = None,
-        namespace: str = None,
-        api: Api = None,
-        label_selector: Union[str, Dict[str, str]] = None,
-        field_selector: Union[str, Dict[str, str]] = None,
+        name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        api: Optional[Api] = None,
+        label_selector: Optional[Union[str, Dict[str, str]]] = None,
+        field_selector: Optional[Union[str, Dict[str, str]]] = None,
         timeout: int = 2,
         **kwargs,
     ) -> APIObjectType:
@@ -281,7 +283,7 @@ class APIObject:
         ) as resp:
             self.raw = resp.json()
 
-    async def delete(self, propagation_policy: str = None) -> None:
+    async def delete(self, propagation_policy: Optional[str] = None) -> None:
         """Delete this object from Kubernetes."""
         data = {}
         if propagation_policy:
@@ -347,7 +349,7 @@ class APIObject:
                 raise NotFoundError(f"Object {self.name} does not exist") from e
             raise e
 
-    async def scale(self, replicas: int = None) -> None:
+    async def scale(self, replicas: Optional[int] = None) -> None:
         """Scale this object in Kubernetes."""
         if not self.scalable:
             raise NotImplementedError(f"{self.kind} is not scalable")
@@ -438,7 +440,7 @@ class APIObject:
         self,
         conditions: Union[List[str], str],
         mode: Literal["any", "all"] = "any",
-        timeout: int = None,
+        timeout: Optional[int] = None,
     ):
         """Wait for conditions to be met.
 
@@ -489,7 +491,7 @@ class APIObject:
                 if await self._test_conditions(conditions, mode=mode):
                     return
 
-    async def annotate(self, annotations: dict = None, **kwargs) -> None:
+    async def annotate(self, annotations: Optional[dict] = None, **kwargs) -> None:
         """Annotate this object in Kubernetes."""
         if annotations is None:
             annotations = kwargs
@@ -497,7 +499,7 @@ class APIObject:
             raise ValueError("No annotations provided")
         await self.async_patch({"metadata": {"annotations": annotations}})
 
-    async def label(self, labels: dict = None, **kwargs) -> None:
+    async def label(self, labels: Optional[dict] = None, **kwargs) -> None:
         """Add labels to this object in Kubernetes.
 
         Labels can be passed as a dictionary or as keyword arguments.
@@ -896,7 +898,7 @@ class Pod(APIObject):
     def portforward(
         self,
         remote_port: int,
-        local_port: int = None,
+        local_port: Optional[int] = None,
         address: List[str] | str = "127.0.0.1",
     ) -> int:
         """Port forward a pod.
@@ -938,10 +940,10 @@ class Pod(APIObject):
         self,
         command: List[str],
         *,
-        container: str = None,
-        stdin: Union(str | bytes | BinaryIO) = None,
-        stdout: BinaryIO = None,
-        stderr: BinaryIO = None,
+        container: Optional[str] = None,
+        stdin: Optional[Union(str | bytes | BinaryIO)] = None,
+        stdout: Optional[BinaryIO] = None,
+        stderr: Optional[BinaryIO] = None,
         check: bool = True,
         capture_output: bool = True,
     ):
@@ -966,10 +968,10 @@ class Pod(APIObject):
         self,
         command: List[str],
         *,
-        container: str = None,
-        stdin: Union(str | bytes | BinaryIO) = None,
-        stdout: BinaryIO = None,
-        stderr: BinaryIO = None,
+        container: Optional[str] = None,
+        stdin: Optional[Union(str | bytes | BinaryIO)] = None,
+        stdout: Optional[BinaryIO] = None,
+        stderr: Optional[BinaryIO] = None,
         check: bool = True,
         capture_output: bool = True,
     ):
@@ -1264,7 +1266,7 @@ class Service(APIObject):
     def portforward(
         self,
         remote_port: int,
-        local_port: int = None,
+        local_port: Optional[int] = None,
         address: str | List[str] = "127.0.0.1",
     ) -> int:
         """Port forward a service.
@@ -1665,7 +1667,10 @@ def new_class(
 
 
 def object_from_spec(
-    spec: dict, api: Api = None, allow_unknown_type: bool = False, _asyncio: bool = True
+    spec: dict,
+    api: Optional[Api] = None,
+    allow_unknown_type: bool = False,
+    _asyncio: bool = True,
 ) -> APIObject:
     """Create an APIObject from a Kubernetes resource spec.
 
@@ -1691,7 +1696,10 @@ def object_from_spec(
 
 
 async def object_from_name_type(
-    name: str, namespace: str = None, api: Api = None, _asyncio: bool = True
+    name: str,
+    namespace: Optional[str] = None,
+    api: Optional[Api] = None,
+    _asyncio: bool = True,
 ) -> APIObject:
     """Create an APIObject from a Kubernetes resource name.
 
@@ -1722,7 +1730,7 @@ async def object_from_name_type(
 
 async def objects_from_files(
     path: Union[str, pathlib.Path],
-    api: Api = None,
+    api: Optional[Api] = None,
     recursive: bool = False,
     _asyncio: bool = True,
 ) -> List[APIObject]:

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -8,7 +8,7 @@ import random
 import socket
 import sys
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING, BinaryIO, List
+from typing import TYPE_CHECKING, BinaryIO, List, Optional
 
 import anyio
 import httpx_ws
@@ -77,7 +77,7 @@ class PortForward:
         self,
         resource: APIObject,
         remote_port: int,
-        local_port: int = None,
+        local_port: Optional[int] = None,
         address: List[str] | str = "127.0.0.1",
     ) -> None:
         with suppress(sniffio.AsyncLibraryNotFoundError):

--- a/kr8s/asyncio/_api.py
+++ b/kr8s/asyncio/_api.py
@@ -2,17 +2,18 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import asyncio
 import threading
+from typing import Optional
 
 from kr8s._api import Api as _AsyncApi
 from kr8s._api import hash_kwargs
 
 
 async def api(
-    url: str = None,
-    kubeconfig: str = None,
-    serviceaccount: str = None,
-    namespace: str = None,
-    context: str = None,
+    url: Optional[str] = None,
+    kubeconfig: Optional[str] = None,
+    serviceaccount: Optional[str] = None,
+    namespace: Optional[str] = None,
+    context: Optional[str] = None,
     _asyncio: bool = True,
 ) -> _AsyncApi:
     """Create a :class:`kr8s.asyncio.Api` object for interacting with the Kubernetes API.

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from kr8s._api import Api
 
@@ -10,10 +10,10 @@ from ._api import api as _api
 async def get(
     kind: str,
     *names: List[str],
-    namespace: str = None,
-    label_selector: Union[str, Dict] = None,
-    field_selector: Union[str, Dict] = None,
-    as_object: object = None,
+    namespace: Optional[str] = None,
+    label_selector: Optional[Union[str, Dict]] = None,
+    field_selector: Optional[Union[str, Dict]] = None,
+    as_object: Optional[object] = None,
     api=None,
     _asyncio=True,
     **kwargs,
@@ -81,10 +81,10 @@ async def version(api=None, _asyncio=True):
 
 async def watch(
     kind: str,
-    namespace: str = None,
-    label_selector: Union[str, Dict] = None,
-    field_selector: Union[str, Dict] = None,
-    since: str = None,
+    namespace: Optional[str] = None,
+    label_selector: Optional[Union[str, Dict]] = None,
+    field_selector: Optional[Union[str, Dict]] = None,
+    since: Optional[str] = None,
     api=None,
     _asyncio=True,
 ):


### PR DESCRIPTION
Continuing on the path of #381 this PR runs [`no_implicit_optional`](https://github.com/hauntsaninja/no_implicit_optional) on `kr8s` to add missing `Optional` types.

This removes around 70 `mypy` warnings.