### PR TITLE
Fix listing all namespaces when base URL is specified

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -111,6 +111,7 @@ class Api(object):
             headers=headers,
             verify=await self.auth.ssl_context(),
             timeout=self._timeout,
+            follow_redirects=True,
         )
 
     def _construct_url(
@@ -130,7 +131,7 @@ class Api(object):
         parts = [base]
         if version:
             parts.append(version)
-        if namespace is not None:
+        if namespace:
             parts.extend(["namespaces", namespace])
         parts.append(url)
         return "/".join(parts)

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -31,7 +31,7 @@ class KubeAuth:
         self.client_key_file: Optional[PathType] = None
         self.server_ca_file: Optional[PathType] = None
         self.token: Optional[str] = None
-        self.namespace: Optional[str] = namespace
+        self._namespace: Optional[str] = namespace
         self.active_context: str = ""
         self.kubeconfig: KubeConfigSet
         self.tls_server_name: Optional[str] = None
@@ -99,6 +99,14 @@ class KubeAuth:
             if self.server_ca_file:
                 sslcontext.load_verify_locations(cafile=self.server_ca_file)
             return sslcontext
+
+    @property
+    def namespace(self):
+        return self._namespace if self._namespace else "default"
+
+    @namespace.setter
+    def namespace(self, value: str):
+        self._namespace = value
 
     async def _load_kubeconfig(self) -> None:
         """Load kubernetes auth from kubeconfig."""

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -101,7 +101,7 @@ class KubeAuth:
             return sslcontext
 
     @property
-    def namespace(self):
+    def namespace(self) -> str:
         return self._namespace if self._namespace else "default"
 
     @namespace.setter
@@ -139,8 +139,8 @@ class KubeAuth:
             self.active_context = self.kubeconfig.contexts[0]["name"]
 
         # Load configuration options from the context
-        if self.namespace is None:
-            self.namespace = self.kubeconfig.current_namespace
+        if self._namespace is None:
+            self._namespace = self.kubeconfig.current_namespace
 
         # If no cluster is found in the context, assume it's a service account
         if not self._context["cluster"]:

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -151,7 +151,7 @@ async def test_bad_api_version():
             pass  # pragma: no cover
 
 
-@pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system"])
+@pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system", None])
 async def test_get_pods(namespace):
     pods = await kr8s.asyncio.get("pods", namespace=namespace)
     assert isinstance(pods, list)

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -151,7 +151,7 @@ async def test_bad_api_version():
             pass  # pragma: no cover
 
 
-@pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system", None])
+@pytest.mark.parametrize("namespace", [kr8s.ALL, "kube-system"])
 async def test_get_pods(namespace):
     pods = await kr8s.asyncio.get("pods", namespace=namespace)
     assert isinstance(pods, list)


### PR DESCRIPTION
Fixes the issues covered in #284. When specifying the baseurl of a server there seems to be a couple of problems with constructing the API urls.

I also noticed that when setting `kr8s.api(url="...")` the load kubeconfig code is never called, so the default namespace is never loaded. I added a quick workaround for this so that we get the default namespace, but I'm not sure if this is correct behaviour. I'll open a new issue to explore this further.