### PR TITLE
Add hook to sphinx-autoapi to fix sync wrapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,11 +87,15 @@ def remove_async_property(app, what, name, obj, skip, options):
         for child in obj.children:
             if child.type == "method":
                 if child.name.startswith("async_"):
-                    # TODO figure out how to skip this child
+                    child.properties.append("sync-wrapped")
                     continue
                 if not child.name.startswith("_"):
                     if "async" in child.properties:
                         child.properties.remove("async")
+
+    if what == "method" and "sync-wrapped" in obj.properties:
+        skip = True
+    return skip
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,11 +81,14 @@ def remove_async_property(app, what, name, obj, skip, options):
     Also skip public ``async_`` methods as they are only intended
     to be used internally by other sync wrapped objects.
     """
-    if (
-        what == "class"
-        and "kr8s.objects" in name
-        and obj.bases
-        and "kr8s._objects" in obj.bases[0]
+    if what == "class" and (
+        # Infer that the class is a sync wrapped class if it is the kr8s.Api class,
+        # or is in kr8s.objects and inherits from a class in kr8s._objects.
+        name == "kr8s.Api"
+        or ("kr8s.objects" in name and obj.bases and "kr8s._objects" in obj.bases[0])
+        # FIXME: It would be better to just check if the class is decorated with @sync
+        # but sphinx-autoapi does not currently keep track of decorators
+        # See https://github.com/readthedocs/sphinx-autoapi/issues/459
     ):
         for child in obj.children:
             if child.type == "method":

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,5 +72,27 @@ intersphinx_mapping = {
 }
 
 
+def remove_async_property(app, what, name, obj, skip, options):
+    """Remove async property from sync wrapped methods.
+
+    Find all sync classes that inherit from async classes
+    and remove the async property from their wrapped methods.
+    """
+    if (
+        what == "class"
+        and "kr8s.objects" in name
+        and obj.bases
+        and "kr8s._objects" in obj.bases[0]
+    ):
+        for child in obj.children:
+            if child.type == "method":
+                if not child.name.startswith("async_") and not child.name.startswith(
+                    "_"
+                ):
+                    if "async" in child.properties:
+                        child.properties.remove("async")
+
+
 def setup(app):
     app.add_css_file("css/custom.css")
+    app.connect("autoapi-skip-member", remove_async_property)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,9 @@ def remove_async_property(app, what, name, obj, skip, options):
 
     Find all sync classes that inherit from async classes
     and remove the async property from their wrapped methods.
+
+    Also skip public ``async_`` methods as they are only intended
+    to be used internally by other sync wrapped objects.
     """
     if (
         what == "class"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,13 +93,14 @@ def remove_async_property(app, what, name, obj, skip, options):
         for child in obj.children:
             if child.type == "method":
                 if child.name.startswith("async_"):
-                    child.properties.append("sync-wrapped")
+                    child.properties.append("private-async-only")
                     continue
                 if not child.name.startswith("_"):
                     if "async" in child.properties:
                         child.properties.remove("async")
+                        child.properties.append("sync-wrapped")
 
-    if what == "method" and "sync-wrapped" in obj.properties:
+    if what == "method" and "private-async-only" in obj.properties:
         skip = True
     return skip
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,6 @@ def remove_async_property(app, what, name, obj, skip, options):
                 if not child.name.startswith("_"):
                     if "async" in child.properties:
                         child.properties.remove("async")
-                        child.properties.append("sync-wrapped")
 
     if what == "method" and "private-async-only" in obj.properties:
         skip = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,9 +86,10 @@ def remove_async_property(app, what, name, obj, skip, options):
     ):
         for child in obj.children:
             if child.type == "method":
-                if not child.name.startswith("async_") and not child.name.startswith(
-                    "_"
-                ):
+                if child.name.startswith("async_"):
+                    # TODO figure out how to skip this child
+                    continue
+                if not child.name.startswith("_"):
                     if "async" in child.properties:
                         child.properties.remove("async")
 


### PR DESCRIPTION
Fixes #422 

This PR adds a plugin for `sphinx-autoapi` which infers whether a class is decorated with `@sync` and removes the `async` metadata property so that is is rendered correctly in docs.

Ideally we could check for certain that a class is decorated with `@sync` but it seems that `sphinx-autoapi` doesn't keep track of decorators during it's parse phase so there's no way to know this.