### PR TITLE
Support getting unknown types

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -305,7 +305,11 @@ Instead we have focused on making the API extensible so that if there isn't a bu
 
 ### Extending the objects API
 
-To create your own objects you can subclass [](#kr8s.objects.APIObject), however we recommend you use the {py:func}`new_class <kr8s.objects.new_class>` class factory to ensure all of the required attributes are set. These will be used when constructing API calls by the API client.
+To create your own objects which will be a subclass of [](#kr8s.objects.APIObject), however we recommend you use the {py:func}`new_class <kr8s.objects.new_class>` class factory to ensure all of the required attributes are set. These will be used when constructing API calls by the API client.
+
+```{danger}
+Manually subclassing `APIObject` is considered an advanced topic and requires strong understanding of `kr8s` internals and how the sync/async wrapping works. For now it is recommended that you do not do this.
+```
 
 ```python
 from kr8s.objects import new_class
@@ -314,9 +318,7 @@ CustomObject = new_class(
         kind="CustomObject",
         version="example.org",
         namespaced=True,
-        asyncio=False,
     )
-
 ```
 
 The [](#kr8s.objects.APIObject) base class contains helper methods such as `.create()`, `.delete()`, `.patch()`, `.exists()`, etc.
@@ -332,12 +334,7 @@ CustomScalableObject = new_class(
         namespaced=True,
         scalable=True,
         scalable_spec="replicas",  # The spec key to patch when scaling
-        asyncio=False,
     )
-```
-
-```{danger}
-Manually subclassing `APIObject` is considered an advanced topic and requires strong understanding of `kr8s` internals and how the sync/async wrapping works. For now it is recommended that you do not do this.
 ```
 
 ### Using custom objects with other `kr8s` functions

--- a/docs/object.md
+++ b/docs/object.md
@@ -336,11 +336,21 @@ CustomScalableObject = new_class(
     )
 ```
 
+```{danger}
+Manually subclassing `APIObject` is considered an advanced topic and requires strong understanding of `kr8s` internals and how the sync/async wrapping works. For now it is recommended that you do not do this.
+```
+
 ### Using custom objects with other `kr8s` functions
 
-When using the [`kr8s` API](client) some methods such as `kr8s.get("pods")` will want to return kr8s objects, in this case a `Pod`. The API client handles this by looking up all of the subclasses of [`APIObject`](#kr8s.objects.APIObject) and matching the `kind` against the kind returned by the API. If the API returns a kind of object that there is no kr8s object to deserialize into it will raise an exception.
+When using the [`kr8s` API](client) some methods such as `kr8s.get("pods")` will want to return kr8s objects, in this case a `Pod`. The API client handles this by looking up all of the subclasses of [`APIObject`](#kr8s.objects.APIObject) and matching the `kind` against the kind returned by the API. If the API returns a kind of object that there is no kr8s object to deserialize into it will create a new class for you automatically.
 
-When you create your own custom objects that subclass [`APIObject`](#kr8s.objects.APIObject) the client is then able to use those objects in its response.
+```python
+import kr8s
+
+cos = kr8s.get("customobjects")  # If a resource called `customobjects` exists on the server a class will be created dynamically for it
+```
+
+When you create your own custom objects with `new_class` the client is then able to use those objects in its response.
 
 ```python
 import kr8s

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -14,6 +14,7 @@ async def get(
     label_selector: Optional[Union[str, Dict]] = None,
     field_selector: Optional[Union[str, Dict]] = None,
     as_object: Optional[object] = None,
+    allow_unknown_type: bool = True,
     api=None,
     _asyncio=True,
     **kwargs,
@@ -34,6 +35,8 @@ async def get(
         The field selector to filter the resources by
     as_object : object, optional
         The object to populate with the resource data
+    allow_unknown_type : bool, optional
+        Automatically create a class for the resource if none exists
     api : Api, optional
         The api to use to get the resource
 
@@ -69,6 +72,7 @@ async def get(
         label_selector=label_selector,
         field_selector=field_selector,
         as_object=as_object,
+        allow_unknown_type=allow_unknown_type,
         **kwargs,
     )
 

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -317,10 +317,55 @@ async def test_api_timeout() -> None:
 async def test_lookup_kind():
     api = await kr8s.asyncio.api()
 
-    assert await api.lookup_kind("po") == "pods/v1"
-    assert await api.lookup_kind("role") == "roles.rbac.authorization.k8s.io/v1"
-    assert await api.lookup_kind("roles") == "roles.rbac.authorization.k8s.io/v1"
-    assert (
-        await api.lookup_kind("roles.rbac.authorization.k8s.io")
-        == "roles.rbac.authorization.k8s.io/v1"
+    assert await api.lookup_kind("no") == ("node/v1", False)
+    assert await api.lookup_kind("nodes") == ("node/v1", False)
+    assert await api.lookup_kind("po") == ("pod/v1", True)
+    assert await api.lookup_kind("pods/v1") == ("pod/v1", True)
+    assert await api.lookup_kind("role") == ("role.rbac.authorization.k8s.io/v1", True)
+    assert await api.lookup_kind("roles") == ("role.rbac.authorization.k8s.io/v1", True)
+    assert await api.lookup_kind("roles.v1.rbac.authorization.k8s.io") == (
+        "role.rbac.authorization.k8s.io/v1",
+        True,
     )
+    assert await api.lookup_kind("roles.rbac.authorization.k8s.io") == (
+        "role.rbac.authorization.k8s.io/v1",
+        True,
+    )
+
+
+async def test_nonexisting_resource_type():
+    api = await kr8s.asyncio.api()
+
+    with pytest.raises(ValueError):
+        await api.get("foo.bar.baz/v1")
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "csr",
+        "certificatesigningrequest",
+        "certificatesigningrequests",
+        "certificatesigningrequest.certificates.k8s.io",
+        "certificatesigningrequests.certificates.k8s.io",
+        "certificatesigningrequest.v1.certificates.k8s.io",
+        "certificatesigningrequests.v1.certificates.k8s.io",
+        "certificatesigningrequest.certificates.k8s.io/v1",
+        "certificatesigningrequests.certificates.k8s.io/v1",
+    ],
+)
+async def test_dynamic_classes(kind):
+    api = await kr8s.asyncio.api()
+
+    if not any(["istio.io" in r["version"] for r in await api.api_resources()]):
+        pytest.skip("Istio not installed")
+
+    from kr8s.asyncio.objects import get_class
+
+    with pytest.raises(KeyError):
+        get_class("certificatesigningrequest", "certificates.k8s.io/v1")
+
+    with pytest.raises(KeyError):
+        await api.get(kind, allow_unknown_type=False)
+
+    await api.get(kind)

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -312,3 +312,15 @@ async def test_api_timeout() -> None:
     api.timeout = 0.00001
     with pytest.raises(APITimeoutError):
         await api.version()
+
+
+async def test_lookup_kind():
+    api = await kr8s.asyncio.api()
+
+    assert await api.lookup_kind("po") == "pods/v1"
+    assert await api.lookup_kind("role") == "roles.rbac.authorization.k8s.io/v1"
+    assert await api.lookup_kind("roles") == "roles.rbac.authorization.k8s.io/v1"
+    assert (
+        await api.lookup_kind("roles.rbac.authorization.k8s.io")
+        == "roles.rbac.authorization.k8s.io/v1"
+    )

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1124,3 +1124,44 @@ def test_object_setter_from_old_spec(example_pod_spec):
     assert new_po.raw["spec"]["containers"][0]["name"] != "bar"
     new_po.raw["spec"] = po.raw["spec"]
     assert new_po.raw["spec"]["containers"][0]["name"] == "bar"
+
+
+def test_parse_kind():
+    from kr8s._objects import parse_kind
+
+    assert parse_kind("Pod") == ("pod", "", "")
+    assert parse_kind("Pods") == ("pods", "", "")
+    assert parse_kind("pod/v1") == ("pod", "", "v1")
+    assert parse_kind("deploy") == ("deploy", "", "")
+    assert parse_kind("gateway") == ("gateway", "", "")
+    assert parse_kind("gateways") == ("gateways", "", "")
+    assert parse_kind("gateway.networking.istio.io") == (
+        "gateway",
+        "networking.istio.io",
+        "",
+    )
+    assert parse_kind("gateways.networking.istio.io") == (
+        "gateways",
+        "networking.istio.io",
+        "",
+    )
+    assert parse_kind("gateway.v1.networking.istio.io") == (
+        "gateway",
+        "networking.istio.io",
+        "v1",
+    )
+    assert parse_kind("gateways.v1.networking.istio.io") == (
+        "gateways",
+        "networking.istio.io",
+        "v1",
+    )
+    assert parse_kind("gateway.networking.istio.io/v1") == (
+        "gateway",
+        "networking.istio.io",
+        "v1",
+    )
+    assert parse_kind("gateways.networking.istio.io/v1") == (
+        "gateways",
+        "networking.istio.io",
+        "v1",
+    )


### PR DESCRIPTION
Closes #199 

The goal of this PR is to make `kr8s.get(...)` as flexible as `kubectl get ...`.

For example if I have `Istio` installed I can list [`Gateway`](https://istio.io/latest/docs/reference/config/networking/gateway/) objects in the following ways:

```bash
kubectl get gw
kubectl get gateway
kubectl get gateways
kubectl get gateway.networking.istio.io
kubectl get gateways.networking.istio.io
kubectl get gateway.v1.networking.istio.io
kubectl get gateways.v1.networking.istio.io
```

With this PR I can now do the following in `kr8s`.

```python
import kr8s

kr8s.get("gw")
kr8s.get("gateway")
kr8s.get("gateways")
kr8s.get("gateway.networking.istio.io")
kr8s.get("gateways.networking.istio.io")
kr8s.get("gateway.v1.networking.istio.io")
kr8s.get("gateways.v1.networking.istio.io")
```

Previously I would've had to use `Gateway = kr8s.objects.new_class("gateway", "networking.istio.io/v1")` to register the class before I could get it, but after this PR we look this up automatically if no class can be found but the resource exists on the server.

To reinstate the old behaviour we can set the `allow_unknown_type=False`.

```python
import kr8s

kr8s.get("gw", allow_unknown_type=False)
# KeyError: 'No object registered for gateway.networking.istio.io. See https://docs.kr8s.org/en/stable/object.html#extending-the-objects-api for more information on how to register a new object.'
```

You can of course still generate the class manually if you want to use things like the default class methods, or you want a type to work with later.

```python
import kr8s
from kr8s.objects import new_class

Gateway = new_class("gateway", "networking.istio.io/v1")
Gateway.list()
```