### PR TITLE
Ensure dynamic classes are garbage collected between tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+import gc
 import os
 import time
 
 import pytest
 from pytest_kind.cluster import KindCluster
+
+
+@pytest.fixture
+def ensure_gc():
+    """Ensure garbage collection is run before and after the test."""
+    gc.collect()
+    yield
+    gc.collect()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -354,7 +354,7 @@ async def test_nonexisting_resource_type():
         "certificatesigningrequests.certificates.k8s.io/v1",
     ],
 )
-async def test_dynamic_classes(kind):
+async def test_dynamic_classes(kind, ensure_gc):
     from kr8s.asyncio.objects import get_class
 
     api = await kr8s.asyncio.api()


### PR DESCRIPTION
I noticed `kr8s/tests/test_api.py::test_dynamic_classes` failing intermittently because the dynamic class that was generated for each parameter wasn't necessarily being garbage collected between tests and then the test would fail the `pytest.raises(KeyError)` assertion.

This PR adds a fixture that can be used to ensure the garbage collector is run before and after the test.