### PR TITLE
Ensure all submodules are imported

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -3,6 +3,7 @@
 from functools import partial, update_wrapper
 from typing import Optional, Union
 
+from . import asyncio, objects, portforward
 from ._api import ALL
 from ._api import Api as _AsyncApi
 from ._async_utils import run_sync as _run_sync
@@ -170,7 +171,10 @@ __all__ = [
     "ALL",
     "api",
     "api_resources",
+    "asyncio",
     "get",
+    "objects",
+    "portforward",
     "version",
     "watch",
     "whoami",

--- a/kr8s/asyncio/__init__.py
+++ b/kr8s/asyncio/__init__.py
@@ -2,7 +2,18 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from kr8s._api import Api
 
+from . import objects, portforward
 from ._api import api
 from ._helpers import api_resources, get, version, watch, whoami
 
-__all__ = ["api", "api_resources", "get", "version", "watch", "whoami", "Api"]
+__all__ = [
+    "api",
+    "api_resources",
+    "get",
+    "objects",
+    "portforward",
+    "version",
+    "watch",
+    "whoami",
+    "Api",
+]


### PR DESCRIPTION
This PR makes sure that submodules are imported automatically and exposed via `__all__`.

```python
import kr8s

pods = kr8s.objects.Pod.list()  
# Previously this would fail with `AttributeError: module 'kr8s' has no attribute 'objects'`
# unless you explcitly run `import kr8s.objects`.
```

Auto imported submodules are:

```text
kr8s.asyncio
kr8s.asyncio.objects
kr8s.asyncio.portforward
kr8s.objects
kr8s.portforward
```

I was tempted to leave `kr8s.asyncio` out of the top level import, but this results in circular import errors when calling `import kr8s`.

Automatically importing eveything adds around `50ms` to the import time, which seems worth it to avoid the bugs associated with not importing everything.