### PR TITLE
Turn on `pycodestyle` warnings, `pep8-naming` and `flake8-bugbear` in `ruff`.

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -3,8 +3,8 @@
 """
 This module contains `kr8s`, a simple, extensible Python client library for Kubernetes.
 
-At the top level, `kr8s` provides a synchronous API that wraps the asynchronous API provided by `kr8s.asyncio`. 
-Both APIs are functionally identical with the same objects, method signatures and return values. 
+At the top level, `kr8s` provides a synchronous API that wraps the asynchronous API provided by `kr8s.asyncio`.
+Both APIs are functionally identical with the same objects, method signatures and return values.
 """
 from functools import partial, update_wrapper
 from typing import Dict, List, Optional, Union

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -372,7 +372,7 @@ class Api(object):
             try:
                 kind, namespaced = await self.async_lookup_kind(kind)
             except ServerError as e:
-                warnings.warn(str(e))
+                warnings.warn(str(e), stacklevel=1)
             if isinstance(kind, str):
                 try:
                     obj_cls = get_class(kind, _asyncio=self._asyncio)

--- a/kr8s/_async_utils.py
+++ b/kr8s/_async_utils.py
@@ -228,7 +228,7 @@ async def check_output(*args, **kwargs) -> str:
 
 
 @asynccontextmanager
-async def NamedTemporaryFile(
+async def NamedTemporaryFile(  # noqa: N802
     *args, delete: bool = True, **kwargs
 ) -> AsyncGenerator[anyio.Path, None]:
     """Create a temporary file that is deleted when the context exits."""

--- a/kr8s/_async_utils.py
+++ b/kr8s/_async_utils.py
@@ -190,7 +190,7 @@ def sync(source: C) -> C:
         43
 
     """
-    setattr(source, "_asyncio", False)
+    setattr(source, "_asyncio", False)  # noqa: B010
     for name in dir(source):
         method = getattr(source, name)
 
@@ -202,10 +202,10 @@ def sync(source: C) -> C:
                 setattr(source, name, run_sync(function))
 
         elif name == "__aenter__" and not hasattr(source, "__enter__"):
-            setattr(source, "__enter__", run_sync(method))
+            setattr(source, "__enter__", run_sync(method))  # noqa: B010
 
         elif name == "__aexit__" and not hasattr(source, "__exit__"):
-            setattr(source, "__exit__", run_sync(method))
+            setattr(source, "__exit__", run_sync(method))  # noqa: B010
 
     return source
 

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -136,8 +136,8 @@ class APIObject:
         """Name of the Kubernetes resource."""
         try:
             return self.raw["metadata"]["name"]
-        except KeyError:
-            raise ValueError("Resource does not have a name")
+        except KeyError as e:
+            raise ValueError("Resource does not have a name") from e
 
     @property
     def namespace(self) -> Optional[str]:
@@ -596,8 +596,8 @@ class APIObject:
         """Return a lightkube representation of this object."""
         try:
             from lightkube import codecs
-        except ImportError:
-            raise ImportError("lightkube is not installed")
+        except ImportError as e:
+            raise ImportError("lightkube is not installed") from e
         return codecs.from_dict(self.raw)
 
     def to_pykube(self, api) -> Any:
@@ -617,8 +617,8 @@ class APIObject:
         """
         try:
             import pykube  # type: ignore
-        except ImportError:
-            raise ImportError("pykube is not installed")
+        except ImportError as e:
+            raise ImportError("pykube is not installed") from e
         try:
             pykube_cls = getattr(pykube.objects, self.kind)
         except AttributeError:

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -236,8 +236,8 @@ class PortForward:
                 # TODO Support multiple channels for multiple ports.
                 try:
                     await ws.send_bytes(b"\x00" + data)
-                except ConnectionResetError:
-                    raise ConnectionClosedError("Websocket closed")
+                except ConnectionResetError as e:
+                    raise ConnectionClosedError("Websocket closed") from e
 
     async def _ws_to_tcp(self, ws, writer) -> None:
         channels = []

--- a/kr8s/asyncio/objects.py
+++ b/kr8s/asyncio/objects.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 """Objects to represent Kubernetes resources.
 
-This module provides classes that represent Kubernetes resources. 
+This module provides classes that represent Kubernetes resources.
 These classes are used to interact with resources in the Kubernetes API server.
 """
 from kr8s._objects import (

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 """Objects to represent Kubernetes resources.
 
-This module provides classes that represent Kubernetes resources. 
+This module provides classes that represent Kubernetes resources.
 These classes are used to interact with resources in the Kubernetes API server.
 """
 from functools import partial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["D", "E", "F", "I"]
+select = ["D", "E", "W", "F", "I"]
 ignore = [
     "D101", # Missing docstring in public class
     "D212", # Multi-line docstring summary should start at the first line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["D", "E", "W", "F", "I"]
+select = ["D", "E", "W", "F", "I", "N"]
 ignore = [
     "D101", # Missing docstring in public class
     "D212", # Multi-line docstring summary should start at the first line
@@ -136,11 +136,11 @@ target-version = "py310"
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"kr8s/tests/*" = ["D"]
-"conftest.py" = ["D"]
-"examples/*" = ["D"]
-"docs/*" = ["D"]
-"ci/*" = ["D"]
+"kr8s/tests/*" = ["D", "N"]
+"conftest.py" = ["D", "N"]
+"examples/*" = ["D", "N"]
+"docs/*" = ["D", "N"]
+"ci/*" = ["D", "N"]
 
 [tool.mypy]
 exclude = ["examples", "tests", "venv", "ci", "docs", "conftest.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ build-backend = "hatchling.build"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["D", "E", "W", "F", "I", "N"]
+select = ["D", "E", "W", "F", "I", "N", "B"]
 ignore = [
     "D101", # Missing docstring in public class
     "D212", # Multi-line docstring summary should start at the first line
@@ -136,11 +136,11 @@ target-version = "py310"
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"kr8s/tests/*" = ["D", "N"]
-"conftest.py" = ["D", "N"]
-"examples/*" = ["D", "N"]
-"docs/*" = ["D", "N"]
-"ci/*" = ["D", "N"]
+"kr8s/tests/*" = ["D", "N", "B"]
+"conftest.py" = ["D", "N", "B"]
+"examples/*" = ["D", "N", "B"]
+"docs/*" = ["D", "N", "B"]
+"ci/*" = ["D", "N", "B"]
 
 [tool.mypy]
 exclude = ["examples", "tests", "venv", "ci", "docs", "conftest.py"]


### PR DESCRIPTION
Turn on some more linting rules and fix up a couple of issues.