### PR TITLE
 Make getting resource by name more efficient by using a field selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ cython_debug/
 
 docs/autoapi/
 _version.py
+
+# Jetbrains IDEs
+.idea/

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -252,7 +252,11 @@ class APIObject:
             if name:
                 try:
                     resources = await api.async_get(
-                        cls, name, namespace=namespace, **kwargs
+                        cls,
+                        name,
+                        namespace=namespace,
+                        field_selector={"metadata.name": name},
+                        **kwargs,
                     )
                 except ServerError as e:
                     if e.response and e.response.status_code == 404:


### PR DESCRIPTION
In case you have a large number of resources getting a resource by name can get very inefficient, esp in terms of memory usage. Currently all resources are retrieved, then filtered for the name on the client side. This behavior is also very surprising for a function taking a single name.