### PR TITLE
Improve type annotation for APIObject constructor

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -34,6 +34,7 @@ from kr8s._data_utils import (
 )
 from kr8s._exceptions import NotFoundError, ServerError
 from kr8s._exec import Exec
+from kr8s._types import SpecType, SupportsKeysAndGetItem
 from kr8s.asyncio.portforward import PortForward as AsyncPortForward
 from kr8s.portforward import PortForward as SyncPortForward
 
@@ -54,10 +55,10 @@ class APIObject:
     _asyncio: bool = True
 
     def __init__(
-        self, resource: dict, namespace: str | None = None, api: Api | None = None
+        self, resource: SpecType, namespace: str | None = None, api: Api | None = None
     ) -> None:
         """Initialize an APIObject."""
-        with contextlib.suppress(TypeError, ValueError):
+        if isinstance(resource, SupportsKeysAndGetItem):
             resource = dict(resource)
         if isinstance(resource, str):
             self.raw = {"metadata": {"name": resource}}

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -58,19 +58,19 @@ class APIObject:
         self, resource: SpecType, namespace: str | None = None, api: Api | None = None
     ) -> None:
         """Initialize an APIObject."""
-        if isinstance(resource, SupportsKeysAndGetItem):
-            resource = dict(resource)
-        if isinstance(resource, str):
-            self.raw = {"metadata": {"name": resource}}
-        elif isinstance(resource, dict):
+        if isinstance(resource, dict):
             self.raw = resource
+        elif isinstance(resource, SupportsKeysAndGetItem):
+            self.raw = dict(resource)
+        elif isinstance(resource, str):
+            self.raw = {"metadata": {"name": resource}}
         elif hasattr(resource, "to_dict"):
             self.raw = resource.to_dict()
-        elif hasattr(resource, "obj"):
+        elif hasattr(resource, "obj") and isinstance(resource.obj, dict):
             self.raw = resource.obj
         else:
             raise ValueError(
-                "resource must be a dict, string, have an obj attribute or a to_dict method"
+                "resource must be a dict, string, have a to_dict method or an obj attribute containing a dict"
             )
         if namespace is not None:
             self.raw["metadata"]["namespace"] = namespace  # type: ignore

--- a/kr8s/_types.py
+++ b/kr8s/_types.py
@@ -1,8 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 from os import PathLike
-from typing import TYPE_CHECKING, List, Protocol, Union, runtime_checkable
+from typing import (
+    TYPE_CHECKING,
+    Iterable,
+    List,
+    Protocol,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
 
+_KT = TypeVar("_KT")
+_VT_co = TypeVar("_VT_co", covariant=True)
 PathType = Union[str, PathLike[str]]
 
 if TYPE_CHECKING:
@@ -14,3 +24,29 @@ class APIObjectWithPods(Protocol):
     """An APIObject subclass that contains other Pod objects."""
 
     async def async_ready_pods(self) -> List["Pod"]: ...
+
+
+@runtime_checkable
+class SupportsKeysAndGetItem(Protocol[_KT, _VT_co]):
+    """Copied from _typeshed.SupportsKeysAndGetItem to avoid importing it and make runtime checkable."""
+
+    def keys(self) -> Iterable[_KT]: ...
+    def __getitem__(self, key: _KT, /) -> _VT_co: ...
+
+
+@runtime_checkable
+class SupportsToDict(Protocol):
+    """An object that can be converted to a dictionary."""
+
+    def to_dict(self) -> dict: ...
+
+
+@runtime_checkable
+class SupportsObjAttr(Protocol):
+    """An object that has an `obj` dict attribute."""
+
+    obj: dict
+
+
+# Type that can be converted to a Kubernetes spec.
+SpecType = Union[dict, str, SupportsKeysAndGetItem, SupportsToDict, SupportsObjAttr]

--- a/kr8s/_types.py
+++ b/kr8s/_types.py
@@ -34,14 +34,12 @@ class SupportsKeysAndGetItem(Protocol[_KT, _VT_co]):
     def __getitem__(self, key: _KT, /) -> _VT_co: ...
 
 
-@runtime_checkable
 class SupportsToDict(Protocol):
     """An object that can be converted to a dictionary."""
 
     def to_dict(self) -> dict: ...
 
 
-@runtime_checkable
 class SupportsObjAttr(Protocol):
     """An object that has an `obj` dict attribute."""
 


### PR DESCRIPTION
The `resource` argument in all `APIObject` based classes is annotated to take a `dict`, but it's far more flexible than that.

This PR fixes the type annotation by replacing it with one that accurately reflects what it supports.

I also replaced a `contextlib.suppress(...)` with an `isinstance` and `Protocol` which seems much more pleasant.