### PR TITLE
Ensure hatch is installed with the correct Python version in CI

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -38,7 +38,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install hatch
-        run: pipx install hatch
+        run: |
+          python3 -m pip install --user pipx
+          python3 -m pipx install hatch
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}

--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -38,9 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install hatch
-        run: |
-          python3 -m pip install --user pipx
-          python3 -m pipx install hatch
+        run: pip install hatch
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}

--- a/kr8s/_types.py
+++ b/kr8s/_types.py
@@ -4,7 +4,6 @@ from os import PathLike
 from typing import (
     TYPE_CHECKING,
     Iterable,
-    List,
     Protocol,
     TypeVar,
     Union,
@@ -13,7 +12,7 @@ from typing import (
 
 _KT = TypeVar("_KT")
 _VT_co = TypeVar("_VT_co", covariant=True)
-PathType = Union[str, PathLike[str]]
+PathType = Union[str, "PathLike[str]"]
 
 if TYPE_CHECKING:
     from ._objects import Pod
@@ -23,7 +22,7 @@ if TYPE_CHECKING:
 class APIObjectWithPods(Protocol):
     """An APIObject subclass that contains other Pod objects."""
 
-    async def async_ready_pods(self) -> List["Pod"]: ...
+    async def async_ready_pods(self) -> list[Pod]: ...
 
 
 @runtime_checkable

--- a/kr8s/_types.py
+++ b/kr8s/_types.py
@@ -12,7 +12,10 @@ from typing import (
 
 _KT = TypeVar("_KT")
 _VT_co = TypeVar("_VT_co", covariant=True)
-PathType = Union[str, "PathLike[str]"]
+PathType = Union[
+    str,
+    "PathLike[str]",  # Can remove quotes when Python 3.9 is the minimum version.
+]
 
 if TYPE_CHECKING:
     from ._objects import Pod

--- a/kr8s/_types.py
+++ b/kr8s/_types.py
@@ -4,6 +4,7 @@ from os import PathLike
 from typing import (
     TYPE_CHECKING,
     Iterable,
+    List,
     Protocol,
     TypeVar,
     Union,
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 class APIObjectWithPods(Protocol):
     """An APIObject subclass that contains other Pod objects."""
 
-    async def async_ready_pods(self) -> list[Pod]: ...
+    async def async_ready_pods(self) -> List["Pod"]: ...
 
 
 @runtime_checkable


### PR DESCRIPTION
Closes #461 
Contributes towards #459 

Using `pipx` to install `hatch` was causing the system python to be used in `pytest`. Switching to standard `pip` resolves this.

Also fix up some Python 3.8 type annotation things that were previously missed by CI.