### PR TITLE
Add retry to kubectl-ng publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,11 @@ jobs:
       - name: Update kr8s pin in kubectl-ng
         run: |
           pushd examples/kubectl-ng
-          poetry add kr8s==${RELEASE_VERSION}
+          until false; do
+            poetry add kr8s==${RELEASE_VERSION} && break
+            echo "Waiting for kr8s==${RELEASE_VERSION} to be available on PyPI..."
+            sleep 15
+          done
           poetry lock
           popd
       - name: Push new pins back to the repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
   publish-kubectl-ng:
     runs-on: ubuntu-latest
     needs: publish-kr8s
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
For the last few releases the `kubectl-ng` release has failed because it depends on the verison of `kr8s` that was pushed immediatly before it. It takes some time for the new version to be available on PyPI and this race condition is causing releases to fail.

This PR adds some retry logic so that if `kr8s` isn't available yet it waits 15 seconds and tries again. I also added a 30 minute workflow timeout so that if something goes wrong it doesn't retry for too long.