### PR TITLE
Update README logo URL to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="text-align: center; width: 100%;"><img src="branding/logo-wide.png" style="max-height: 200px;" /></div>
+<div style="text-align: center; width: 100%;"><img src="https://raw.githubusercontent.com/kr8s-org/kr8s/main/branding/logo-wide.png" style="max-height: 200px;" /></div>
 
 [![Test](https://github.com/kr8s-org/kr8s/actions/workflows/test-kr8s.yaml/badge.svg)](https://github.com/kr8s-org/kr8s/actions/workflows/test.yaml)
 [![Codecov](https://img.shields.io/codecov/c/gh/kr8s-org/kr8s?logo=codecov&logoColor=ffffff)](https://app.codecov.io/gh/kr8s-org/kr8s)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div style="text-align: center; width: 100%;"><img src="https://raw.githubusercontent.com/kr8s-org/kr8s/main/branding/logo-wide.png" style="max-height: 200px;" /></div>
+<div style="text-align: center; width: 100%;"><img src="https://github.com/kr8s-org/kr8s/raw/v0.17.2/branding/logo-wide.png" style="max-height: 200px;" /></div>
 
 [![Test](https://github.com/kr8s-org/kr8s/actions/workflows/test-kr8s.yaml/badge.svg)](https://github.com/kr8s-org/kr8s/actions/workflows/test.yaml)
 [![Codecov](https://img.shields.io/codecov/c/gh/kr8s-org/kr8s?logo=codecov&logoColor=ffffff)](https://app.codecov.io/gh/kr8s-org/kr8s)


### PR DESCRIPTION
Currently the README logo doesn't display correctly on PyPI because it is linking to the version in the source which only works on GitHub.

### GitHub
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/c853c181-622d-4877-83e6-58842731982d">

### PyPI
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/f500567a-97a5-4f59-8272-3aff74b12c11">

This PR updates the URL to point to the version of the logo hosted on GitHub and I chose to pin it to the 0.17.2 version just in case that file is ever moved or replaced in the future. This way old releases will continue to display correctly. If we every move/change the logo we will just need to update the URL to point to the new one, but that will be a conscious choice.