### PR TITLE
Remove pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7.2.2",
-    "pytest-asyncio>=0.20.3",
     "pytest-kind>=22.11.1",
     "pytest-timeout>=2.1.0",
     "pytest-rerunfailures>=11.1.2",


### PR DESCRIPTION
I feel like we shouldn't need this plugin any more.