### PR TITLE
Improve NotFound exception message to include namespace

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -305,7 +305,7 @@ class APIObject:
         if status == 200:
             return True
         if ensure:
-            raise NotFoundError(f"Object {self.name} does not exist")
+            raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}")
         return False
 
     async def create(self) -> None:
@@ -337,7 +337,7 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist") from e
+                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
             raise e
 
     async def refresh(self) -> None:
@@ -357,7 +357,7 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist") from e
+                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
             raise e
 
     async def patch(self, patch, *, subresource=None, type=None) -> None:
@@ -386,7 +386,7 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist") from e
+                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
             raise e
 
     async def scale(self, replicas: int | None = None) -> None:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -305,7 +305,9 @@ class APIObject:
         if status == 200:
             return True
         if ensure:
-            raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}")
+            raise NotFoundError(
+                f"Object {self.name} does not exist in {self.namespace}"
+            )
         return False
 
     async def create(self) -> None:
@@ -337,7 +339,9 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
+                raise NotFoundError(
+                    f"Object {self.name} does not exist in {self.namespace}"
+                ) from e
             raise e
 
     async def refresh(self) -> None:
@@ -357,7 +361,9 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
+                raise NotFoundError(
+                    f"Object {self.name} does not exist in {self.namespace}"
+                ) from e
             raise e
 
     async def patch(self, patch, *, subresource=None, type=None) -> None:
@@ -386,7 +392,9 @@ class APIObject:
                 self.raw = resp.json()
         except ServerError as e:
             if e.response and e.response.status_code == 404:
-                raise NotFoundError(f"Object {self.name} does not exist in {self.namespace}") from e
+                raise NotFoundError(
+                    f"Object {self.name} does not exist in {self.namespace}"
+                ) from e
             raise e
 
     async def scale(self, replicas: int | None = None) -> None:


### PR DESCRIPTION
While investigating https://github.com/dask/dask-kubernetes/issues/903 it felt useful to know which namespace `kr8s` is looking in for a resource, but the `NotFound` exception doesn't show this. This PR improves the error message to include the namespace.