### PR TITLE
Check if embedded cert is base64 encoded before decoding

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import base64
-import binascii
 import json
 import os
 import pathlib
@@ -193,12 +192,10 @@ class KubeAuth:
                 )
         if "client-key-data" in self._user:
             async with NamedTemporaryFile(delete=False) as key_file:
-                try:
-                    key_data = base64.b64decode(
-                        self._user["client-key-data"], validate=True
-                    )
-                except binascii.Error:
+                if "-----" in self._user["client-key-data"]:
                     key_data = self._user["client-key-data"].encode()
+                else:
+                    key_data = base64.b64decode(self._user["client-key-data"])
                 await key_file.write_bytes(key_data)
                 self.client_key_file = str(key_file)
         if "client-certificate" in self._user:
@@ -212,12 +209,10 @@ class KubeAuth:
                 )
         if "client-certificate-data" in self._user:
             async with NamedTemporaryFile(delete=False) as cert_file:
-                try:
-                    cert_data = base64.b64decode(
-                        self._user["client-certificate-data"], validate=True
-                    )
-                except binascii.Error:
+                if "-----" in self._user["client-certificate-data"]:
                     cert_data = self._user["client-certificate-data"].encode()
+                else:
+                    cert_data = base64.b64decode(self._user["client-certificate-data"])
                 await cert_file.write_bytes(cert_data)
                 self.client_cert_file = str(cert_file)
         if "certificate-authority" in self._cluster:
@@ -231,12 +226,13 @@ class KubeAuth:
                 )
         if "certificate-authority-data" in self._cluster:
             async with NamedTemporaryFile(delete=False) as ca_file:
-                try:
-                    ca_data = base64.b64decode(
-                        self._cluster["certificate-authority-data"], validate=True
-                    )
-                except binascii.Error:
+                if "-----" in self._cluster["certificate-authority-data"]:
                     ca_data = self._cluster["certificate-authority-data"].encode()
+                else:
+                    ca_data = base64.b64decode(
+                        self._cluster["certificate-authority-data"]
+                    )
+
                 await ca_file.write_bytes(ca_data)
                 self.server_ca_file = str(ca_file)
         if "token" in self._user:

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -73,9 +73,15 @@ async def kubeconfig_with_decoded_certs(k8s_cluster):
 
 @pytest.fixture
 async def kubeconfig_with_line_breaks_in_certs(k8s_cluster):
-    def insert_every(input_str: str, substring: str, interval: int) -> str:
+    def insert_every(instring: str, substring: str, interval: int) -> str:
+        """Insert a substring every interval characters in instring.
+
+        Example:
+            >>> insert_every("abcdefghi", ".", 3)
+            "abc.def.ghi"
+        """
         return substring.join(
-            input_str[i : i + interval] for i in range(0, len(input_str), interval)
+            instring[i : i + interval] for i in range(0, len(instring), interval)
         )
 
     kubeconfig = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())


### PR DESCRIPTION
Fixes #484

Instead of trying to base64 decode the certs and failing when they are stored in plain-text this PR checks if they are certs and only decodes them if they are.

This fixes configs which contain new lines in their base64 encoded data (which is technically not valid base64, but decodes fine).

This should not break folks who have plain text certs, which is what the previous try/except behaviour was enabling. Added a test to verify this.