### PR TITLE
Load all resource versions and sort them

### DIFF
--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -1,13 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 """Utilities for working with Kubernetes data structures."""
+from __future__ import annotations
+
 import re
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 
 def list_dict_unpack(
-    input_list: List[Dict], key: str = "key", value: str = "value"
-) -> Dict:
+    input_list: list[dict], key: str = "key", value: str = "value"
+) -> dict:
     """Convert a list of dictionaries to a single dictionary.
 
     Args:
@@ -22,8 +24,8 @@ def list_dict_unpack(
 
 
 def dict_list_pack(
-    input_dict: Dict, key: str = "key", value: str = "value"
-) -> List[Dict]:
+    input_dict: dict, key: str = "key", value: str = "value"
+) -> list[dict]:
     """Convert a dictionary to a list of dictionaries.
 
     Args:
@@ -37,7 +39,7 @@ def dict_list_pack(
     return [{key: k, value: v} for k, v in input_dict.items()]
 
 
-def dot_to_nested_dict(dot_notated_key: str, value: Any) -> Dict:
+def dot_to_nested_dict(dot_notated_key: str, value: Any) -> dict:
     """Convert a dot notated key to a nested dictionary.
 
     Args:
@@ -58,7 +60,7 @@ def dot_to_nested_dict(dot_notated_key: str, value: Any) -> Dict:
     return nested_dict
 
 
-def dict_to_selector(selector_dict: Dict) -> str:
+def dict_to_selector(selector_dict: dict) -> str:
     """Convert a dictionary to a Kubernetes selector.
 
     Args:

--- a/kr8s/_data_utils.py
+++ b/kr8s/_data_utils.py
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 """Utilities for working with Kubernetes data structures."""
-from typing import Any, Dict, List
+import re
+from typing import Any, Callable, Dict, List
 
 
 def list_dict_unpack(
@@ -102,3 +103,58 @@ def xdict(*in_dict, **kwargs):
     if len(in_dict) == 1:
         [kwargs] = in_dict
     return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def sort_versions(
+    versions: list[Any], key: Callable = lambda x: x, reverse: bool = False
+) -> list[Any]:
+    """Sort a list of Kubernetes versions by priority.
+
+    Follows the spcification
+    https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority
+
+    Args:
+        versions: A list of Kubernetes versions to sort.
+        key: A function to extract the version string from each element in the list.
+            Defaults to the identity function
+        reverse: If True, sort in descending order. Defaults to False
+
+    Returns:
+        A list of Kubernetes versions sorted by priority.
+
+    Examples:
+        >>> sort_versions(["v1", "v2", "v2beta1"])
+        ["v2", "v1", "v2beta1"]
+
+        >>> sort_versions(["v1beta2", "foo1", "foo10", "v1"])
+        ["v1", "v1beta2", "foo1", "foo10"]
+    """
+    pattern = r"^v\d+((alpha|beta)\d+)?$"
+    stable = []
+    alphas = []
+    betas = []
+    others = []
+    for version in versions:
+        if re.match(pattern, key(version)) is not None:
+            if "alpha" in key(version):
+                alphas.append(version)
+            elif "beta" in key(version):
+                betas.append(version)
+            else:
+                stable.append(version)
+        else:
+            others.append(version)
+
+    stable = sorted(stable, key=lambda v: int(key(v)[1:]), reverse=True)
+    betas = sorted(
+        betas, key=lambda v: tuple(map(int, key(v)[1:].split("beta"))), reverse=True
+    )
+    alphas = sorted(
+        alphas, key=lambda v: tuple(map(int, key(v)[1:].split("alpha"))), reverse=True
+    )
+    others = sorted(others, key=lambda v: key(v))
+
+    output = stable + betas + alphas + others
+    if reverse:
+        output.reverse()
+    return output

--- a/kr8s/tests/test_data_utils.py
+++ b/kr8s/tests/test_data_utils.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2024, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
+import random
+
 import pytest
 
 from kr8s._data_utils import (
@@ -7,6 +9,7 @@ from kr8s._data_utils import (
     dict_to_selector,
     dot_to_nested_dict,
     list_dict_unpack,
+    sort_versions,
     xdict,
 )
 
@@ -70,3 +73,50 @@ def test_xdict():
             "foo": "bar",
             "baz": "qux",
         }
+
+
+def test_sort_version_priorities():
+    # Sample list based on list from Kubernetes documentation
+    # https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority
+    versions = [
+        "v200",
+        "v10",
+        "v2",
+        "v1",
+        "v11beta2",
+        "v10beta3",
+        "v3beta1",
+        "v12alpha1",
+        "v11alpha2",
+        "v11alpha1",
+        "v3alpha1",
+        "12345",
+        "foo1",
+        "foo10",
+        "helloworld",
+        "vfoobaralpha1",
+    ]
+
+    # Select some random permutations of the above list and ensure they get correctly sorted
+    sample = versions.copy()  # Create a copy that we can shuffle
+    random.seed(42)  # Ensure the same random order each time for deterministic tests
+    for _ in range(30):
+        random.shuffle(sample)
+        assert sort_versions(list(sample)) == versions
+
+
+def test_sort_version_priorities_key():
+    versions = [
+        {"version": "v2"},
+        {"version": "v1"},
+        {"version": "v1beta2"},
+        {"version": "v1beta1"},
+        {"version": "v1alpha1"},
+    ]
+
+    # Select some random permutations of the above list and ensure they get correctly sorted
+    sample = versions.copy()  # Create a copy that we can shuffle
+    random.seed(42)  # Ensure the same random order each time for deterministic tests
+    for _ in range(30):
+        random.shuffle(sample)
+        assert sort_versions(list(sample), key=lambda x: x["version"]) == versions


### PR DESCRIPTION
Fixes #482 

This PR reads all API versions for each group instead of just reading the latest. This should fix the issue from #482 where a CRD has been dropped from the latest version but you still want to use it.

I've also implemented a version sorting utility so that we can ensure the list of resources is sorted correctly. This means that if you try and create a new class for an object that has multiple versions the latest version will be chosen automatically.