### PR TITLE
Extend Kubernetes version support to match cloud support

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,5 +18,14 @@ $ conda install -c conda-forge kr8s
 
 ## Supported Kubernetes Versions
 
-We endeavor to support all Kubernetes versions that are [actively supported by the Kubernetes community](https://kubernetes.io/releases/).
-Kubernetes typically releases 3-4 times a year and provides 1 year of patch support.
+We endeavor to support all Kubernetes versions that are [actively supported by the Kubernetes community](https://kubernetes.io/releases/) and popular cloud hosted Kubernetes platforms.
+
+For each version of Kubernetes we check the following end of life dates:
+- [Open Source Kubernetes Maintenance Support](https://endoflife.date/kubernetes)
+- [Google Kubernetes Engine Maintenance Support](https://endoflife.date/google-kubernetes-engine)
+- [Amazon EKS End of Support](https://endoflife.date/amazon-eks)
+- [Azure Kubernetes Service End of Support (not including LTS extensions)](https://endoflife.date/azure-kubernetes-service)
+
+Once a version has reached end of life from all providers we remove it from our CI/testing matrix.
+
+Typically new versions are released 3-4 times a year and each version receives 12-15 months of support.


### PR DESCRIPTION
Closes #467 

Today we test `kr8s` against all currently supported versions of OSS Kubernetes. However the cloud managed Kubernetes services like Amazon EKS, Azure AKS and Google Kubernetes Engine usually support each version for a couple of months longer than the OSS releases.

For example Kubernetes 1.28 is supported in the OSS community until October 28th 2024, however Google Kubernetes Engine will maintain support until February 4th 2025. So we want to keep support in `kr8s` until Google drops support (or whichever cloud drops support last).

This PR updates our update versions script to extends the support dates to match the cloud support dates. This means that older versions will still be tested in CI until support has been dropped by all the cloud vendors.

Note that we are only matching active support from the cloud vendors, not LTS or extended support dates.