### PR TITLE
Run mypy on tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: 'v1.11.2'
     hooks:
     - id: mypy
-      exclude: "examples|tests|venv|ci|docs|conftest.py"
+      exclude: "examples|venv|ci|docs|conftest.py"
       additional_dependencies: [types-pyyaml>=6.0]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.17.0

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -35,7 +35,7 @@ async def test_api_factory(serviceaccount) -> None:
     assert p.api is not k3
 
 
-def test_api_factory_threaded() -> None:
+def test_api_factory_threaded():
     assert len(kr8s.Api._instances) == 0
 
     q = queue.Queue()
@@ -96,13 +96,13 @@ async def test_api_factory_with_kubeconfig(k8s_cluster, serviceaccount) -> None:
     assert p3.api is not k2
 
 
-def test_version_sync() -> None:
+def test_version_sync():
     api = kr8s.api()
     version = api.version()
     assert "major" in version
 
 
-async def test_version_sync_in_async() -> None:
+async def test_version_sync_in_async():
     api = kr8s.api()
     version = api.version()
     assert "major" in version
@@ -129,7 +129,7 @@ async def test_concurrent_api_creation() -> None:
             tg.start_soon(get_api)
 
 
-async def test_both_api_creation_methods_together() -> None:
+async def test_both_api_creation_methods_together():
     async_api = await kr8s.asyncio.api()
     api = kr8s.api()
 
@@ -206,7 +206,7 @@ async def test_api_versions() -> None:
     assert "apps/v1" in versions
 
 
-def test_api_versions_sync() -> None:
+def test_api_versions_sync():
     api = kr8s.api()
     versions = [version for version in api.api_versions()]
     assert "apps/v1" in versions
@@ -253,7 +253,7 @@ def test_sync_get_returns_sync_objects() -> None:
     assert pods[0]._asyncio is False
 
 
-def test_sync_api_returns_sync_objects() -> None:
+def test_sync_api_returns_sync_objects():
     api = kr8s.api()
     pods = api.get("pods", namespace=kr8s.ALL)
     assert pods[0]._asyncio is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ convention = "google"
 "ci/*" = ["D", "N", "B"]
 
 [tool.mypy]
-exclude = ["examples", "tests", "venv", "ci", "docs", "conftest.py"]
+exclude = ["examples", "venv", "ci", "docs", "conftest.py"]
 
 [tool.pyright]
 exclude = ["examples", "**/tests", "venv", "ci", "docs", "conftest.py"]


### PR DESCRIPTION
In order to resolve #491 we are going to need to test our type annotations. Currently tests are excluded from mypy. This PR adds them back in again.

There were a few failures, many related _to_ the sync API annotations highlighted in #491. For now I've just removed the annotation from the test signature so that mypy skips as we do not enforce strict type checking yet (xref #428).

This PR should merge cleanly with no mypy failures, but will allow us to gradually introduce typing into the tests and therefore test the types.