### PR TITLE
Fix loadBalancer attribute name

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -1343,7 +1343,7 @@ class Service(APIObject):
         # If the service is of type LoadBalancer, check if it has endpoints
         if (
             self.spec.type == "LoadBalancer"
-            and len(self.status.load_balancer.ingress or []) == 0
+            and len(self.status.loadBalancer.ingress or []) == 0
         ):
             return False
 


### PR DESCRIPTION
It was highlighted in https://github.com/dask/dask-kubernetes/issues/906 that `kr8s` is accessing the Service `loadBalancer` attribute via the `load_balancer` key. This is likely a bug left over from some previous experiements with automatically converting camel case keys to snake case keys.

This PR switches the syntax to use camel case, which means it should now work as expected. I also opened #495 to track adding full support for camel => snake conversion.