### PR TITLE
Add kubectl-ng cordon/uncordon

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_cordon_uncordon.py
+++ b/examples/kubectl-ng/kubectl_ng/_cordon_uncordon.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+
+import typer
+from rich.console import Console
+
+from kr8s.asyncio.objects import Node
+
+console = Console()
+
+
+# Missing Options
+# TODO --dry-run='none'
+# TODO -l, --selector=''
+
+
+async def cordon(
+    node: str = typer.Argument(..., help="NODE"),
+):
+    """Mark node as unschedulable.
+
+    Examples:
+        # Mark node "foo" as unschedulable
+        kubectl-ng cordon foo
+    """
+    nodes = [await Node.get(node)]
+    for node_instance in nodes:
+        await node_instance.cordon()
+        console.print(f"node/{node_instance.name} cordoned")
+
+
+async def uncordon(
+    node: str = typer.Argument(..., help="NODE"),
+):
+    """Mark node as schedulable.
+
+    Examples:
+        # Mark node "foo" as schedulable
+        kubectl-ng uncordon foo
+    """
+    nodes = [await Node.get(node)]
+    for node_instance in nodes:
+        await node_instance.uncordon()
+        console.print(f"node/{node_instance.name} uncordoned")

--- a/examples/kubectl-ng/kubectl_ng/cli.py
+++ b/examples/kubectl-ng/kubectl_ng/cli.py
@@ -5,6 +5,7 @@ import typer
 from ._api_resources import api_resources
 from ._api_versions import api_versions
 from ._config import config
+from ._cordon_uncordon import cordon, uncordon
 from ._create import create
 from ._delete import delete
 from ._exec import kexec
@@ -16,6 +17,8 @@ from ._wait import wait
 app = typer.Typer(no_args_is_help=True)
 register(app, api_resources)
 register(app, api_versions)
+register(app, cordon)
+register(app, uncordon)
 register(app, create)
 register(app, delete)
 register(app, get)


### PR DESCRIPTION
Implemented `kubectl-ng cordon NODE` and `kubectl-ng uncordon NODE`.

Also found a typing issue with the return type from `APIObject.get()`. Updated to use the `Self` type instead.