### PR TITLE
Ensure portfoward's `local_port` keyword follows `kubectl` behavior

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -38,6 +38,7 @@ from kr8s._exceptions import NotFoundError, ServerError
 from kr8s._exec import Exec
 from kr8s._types import SpecType, SupportsKeysAndGetItem
 from kr8s.asyncio.portforward import PortForward as AsyncPortForward
+from kr8s.portforward import LocalPortType
 from kr8s.portforward import PortForward as SyncPortForward
 
 JSONPATH_CONDITION_EXPRESSION = r"jsonpath='{(?P<expression>.*?)}'=(?P<condition>.*)"
@@ -971,12 +972,22 @@ class Pod(APIObject):
     def portforward(
         self,
         remote_port: int,
-        local_port: int | None = None,
+        local_port: LocalPortType = "match",
         address: list[str] | str = "127.0.0.1",
     ) -> SyncPortForward | AsyncPortForward:
         """Port forward a pod.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Pod.
+
+        Args:
+            remote_port:
+                The port on the Pod to forward to.
+            local_port:
+                The local port to listen on. Defaults to ``"match"``, which will match the ``remote_port``.
+                Set to ``"auto"`` or ``None`` to find an available high port.
+                Set to an ``int`` to specify a specific port.
+            address:
+                List of addresses or address to listen on. Defaults to ["127.0.0.1"], will listen only on 127.0.0.1.
 
         Example:
             This can be used as a an async context manager or with explicit start/stop methods.
@@ -1360,12 +1371,22 @@ class Service(APIObject):
     def portforward(
         self,
         remote_port: int,
-        local_port: int | None = None,
+        local_port: LocalPortType = "match",
         address: str | list[str] = "127.0.0.1",
     ) -> SyncPortForward | AsyncPortForward:
         """Port forward a service.
 
         Returns an instance of :class:`kr8s.portforward.PortForward` for this Service.
+
+        Args:
+            remote_port:
+                The port on the Pod to forward to.
+            local_port:
+                The local port to listen on. Defaults to ``"match"``, which will match the ``remote_port``.
+                Set to ``"auto"`` or ``None`` to find an available high port.
+                Set to an ``int`` to specify a specific port.
+            address:
+                List of addresses or address to listen on. Defaults to ["127.0.0.1"], will listen only on 127.0.0.1.
 
         Example:
             This can be used as a an async context manager or with explicit start/stop methods.

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -8,7 +8,7 @@ import random
 import socket
 import sys
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING, AsyncGenerator, Literal
+from typing import TYPE_CHECKING, AsyncGenerator, Literal, Union
 
 import anyio
 import httpx_ws
@@ -17,7 +17,7 @@ import sniffio
 from ._exceptions import ConnectionClosedError
 from ._types import APIObjectWithPods
 
-LocalPortType = Literal["match", "auto"] | int | None
+LocalPortType = Union[Literal["match", "auto"], int, None]
 
 if TYPE_CHECKING:
     from ._objects import APIObject

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -8,7 +8,10 @@ import threading
 import time
 
 from ._async_utils import sync
+from ._portforward import LocalPortType
 from ._portforward import PortForward as _PortForward
+
+__all__ = ["PortForward", "LocalPortType"]
 
 
 @sync

--- a/kr8s/portforward.py
+++ b/kr8s/portforward.py
@@ -4,6 +4,8 @@
 
 This module provides a class for managing a port forward connection to a Kubernetes Pod or Service.
 """
+from __future__ import annotations
+
 import threading
 import time
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -668,7 +668,7 @@ async def test_pod_logs(example_pod_spec):
 
 async def test_pod_port_forward_context_manager(nginx_service):
     [nginx_pod, *_] = await nginx_service.ready_pods()
-    async with nginx_pod.portforward(80) as port:
+    async with nginx_pod.portforward(80, local_port=None) as port:
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as session:
             resp = await session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200
@@ -683,7 +683,7 @@ def test_pod_port_forward_context_manager_sync(nginx_service):
     nginx_service = SyncService.get(
         nginx_service.name, namespace=nginx_service.namespace
     )
-    with nginx_service.portforward(80) as port:
+    with nginx_service.portforward(80, local_port=None) as port:
         with httpx.Client(timeout=DEFAULT_TIMEOUT) as session:
             resp = session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200
@@ -708,7 +708,7 @@ async def test_pod_port_forward_context_manager_manual(nginx_service):
 async def test_pod_port_forward_start_stop(nginx_service):
     [nginx_pod, *_] = await nginx_service.ready_pods()
     for _ in range(5):
-        pf = nginx_pod.portforward(80)
+        pf = nginx_pod.portforward(80, local_port=None)
         assert pf._bg_task is None
         port = await pf.start()
         assert pf._bg_task is not None
@@ -725,7 +725,7 @@ async def test_pod_port_forward_start_stop(nginx_service):
 
 
 async def test_service_port_forward_context_manager(nginx_service):
-    async with nginx_service.portforward(80) as port:
+    async with nginx_service.portforward(80, local_port=None) as port:
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as session:
             resp = await session.get(f"http://localhost:{port}/")
             assert resp.status_code == 200
@@ -734,7 +734,7 @@ async def test_service_port_forward_context_manager(nginx_service):
 
 
 async def test_service_port_forward_start_stop(nginx_service):
-    pf = nginx_service.portforward(80)
+    pf = nginx_service.portforward(80, local_port=None)
     assert pf._bg_task is None
     port = await pf.start()
     assert pf._bg_task is not None
@@ -752,9 +752,9 @@ async def test_service_port_forward_start_stop(nginx_service):
 async def test_unsupported_port_forward():
     pv = await PersistentVolume({"metadata": {"name": "foo"}})
     with pytest.raises(AttributeError):
-        await pv.portforward(80)
+        await pv.portforward(80, local_port=None)
     with pytest.raises(ValueError):
-        await PortForward(pv, 80).start()
+        await PortForward(pv, 80, local_port=None).start()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #505 

Currently setting `local_port=None` (the default behaviour) when port forwarding chooses a random high port. However this does not match the default behaviour of `kubectl`. As pointed out in #505 there are three different things that `local_port` can be set to in `kubectl`. 

If it is completely omitted it will match the `remote_port`.

```bash
# This binds remote port 80 to port 80 locally
kubectl port-forward po/nginx 80
```

If it is left empty it will choose a random high port.

```bash
# This binds to a random port locally
kubectl port-forward po/nginx :80
```

And finally if it is set then it will be explicitly set.

```bash
# This binds to port 8080 locally
kubectl port-forward po/nginx 8080:80
```

This is a little trickier to implement in a Pythonic way because we usually use `None` or `0` for choosing a random high port. To resolve this in this PR I've added a new optional union type that is either a literal string of `"match"` or `"auto"` or an `int`. If the value is set to `None` it will follow the behaviour or `"auto"` which provides backward compatibility for folks who may explicitly be setting the value to `None`.

**BREAKING: The default value has been changed to `"match"` to mimic the default behaviour of `kubectl`.**

So the `kr8s` Python API now follows the `kubectl` behaviour:

If it is completely omitted it will match the `remote_port`.

```python
from kr8s.objects import Pod

# This binds remote port 80 to port 80 locally
Pod("nginx").portforward(remote_port=80).run_forever()
```

If it is set to `"auto"` or `None` it will choose a random high port.

```python
from kr8s.objects import Pod

# This binds to a random port locally
Pod("nginx").portforward(remote_port=80, local_port="auto").run_forever()

# This is equivalent for backward compatibility
Pod("nginx").portforward(remote_port=80, local_port=None).run_forever()

# This is also equivalent
Pod("nginx").portforward(remote_port=80, local_port=0).run_forever()
```

And finally if it is set then it will be explicitly set.

```python
from kr8s.objects import Pod

# This binds to port 8080 locally
Pod("nginx").portforward(remote_port=80, local_port=8080).run_forever()
```