### PR TITLE
Fix loading Azure LTS support dates

### DIFF
--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -47,7 +47,7 @@ def get_azure_aks_versions():
             {
                 "cycle": x["cycle"],
                 "eol": datetime.strptime(
-                    x["eol"] if not x["lts"] else x["support"], DATE_FORMAT
+                    x["eol"] if not x["lts"] else x["lts"], DATE_FORMAT
                 ),
             }
             for x in data

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -43,12 +43,18 @@ def get_azure_aks_versions():
     print(f"Loading Azure AKS versions from {url}...")
     with urllib.request.urlopen(url) as payload:
         data = json.load(payload)
+
+        # Workaround for https://github.com/kr8s-org/kr8s/issues/514
+        for x in data:
+            if x["cycle"] == "1.27":
+                dates = [x["eol"], x["lts"]]
+                dates.sort()
+                x["eol"], x["lts"] = dates
+
         data = [
             {
                 "cycle": x["cycle"],
-                "eol": datetime.strptime(
-                    x["eol"] if not x["lts"] else x["lts"], DATE_FORMAT
-                ),
+                "eol": datetime.strptime(x["eol"], DATE_FORMAT),
             }
             for x in data
             if datetime.strptime(x["eol"], DATE_FORMAT) > datetime.now()

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -45,11 +45,10 @@ def get_azure_aks_versions():
         data = json.load(payload)
 
         # Workaround for https://github.com/kr8s-org/kr8s/issues/514
+        # Ensure that the `eol` date is the original date and the`lts` date is the extended date.
         for x in data:
-            if x["cycle"] == "1.27":
-                dates = [x["eol"], x["lts"]]
-                dates.sort()
-                x["eol"], x["lts"] = dates
+            if "lts" in x and x["lts"]:
+                x["eol"], x["lts"] = sorted([x["eol"], x["lts"]])
 
         data = [
             {


### PR DESCRIPTION
Closes #514. This PR adds a workaround to ensure that the Azure Kubernetes Service EOL dates are consistent.