### PR TITLE
Add typing extensions to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "httpx>=0.24.1",
     "httpx-ws>=0.5.2",
     "python-box>=7.0.1",
+    "typing_extensions>=4.12.2",
 ]
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
When installing `kr8s` I get this error:

```
  File "/Users/thomasfan/micromamba/envs/kr8s-live/lib/python3.12/site-packages/kr8s/_objects.py", line 25, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
```

This PR adds `typing_extensions` as a dependency, which matches the minimum dependency here:

https://github.com/kr8s-org/kr8s/blob/7aea969f7d4f9ce64a082a18161a26e1f4c82975/examples/kubectl-ng/poetry.lock#L1215-L1217