### PR TITLE
Add workflow to test minimal dependencies

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -16,6 +16,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  deps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.12"
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+      - name: Install kr8s
+        run: pip install -e .
+      - name: Ensure kr8s works
+        run: python -c "import kr8s; print(kr8s.get('nodes'))"
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -59,6 +59,7 @@ jobs:
       matrix:
         # Test the minimal and maximal Python versions only
         python-version: ["3.8", "3.12"]
+        kubernetes-version: ["1.31.2"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -66,6 +67,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
+        with:
+          node_image: kindest/node:v${{ matrix.kubernetes-version }}
       - name: Install kr8s
         run: pip install -e .
       - name: Ensure kr8s works

--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -16,20 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deps:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.12"
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1
-      - name: Install kr8s
-        run: pip install -e .
-      - name: Ensure kr8s works
-        run: python -c "import kr8s; print(kr8s.get('nodes'))"
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -64,3 +50,23 @@ jobs:
       - name: Debug k8s resources
         if: always()
         run: kubectl get all -A
+
+  minimal-deps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test the minimal and maximal Python versions only
+        python-version: ["3.8", "3.12"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+      - name: Install kr8s
+        run: pip install -e .
+      - name: Ensure kr8s works
+        run: python -c "import kr8s; print(kr8s.get('nodes'))"

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -154,9 +154,14 @@ def get_versions():
 def update_workflow(versions, workflow_path):
     workflow_path = Path(workflow_path)
     workflow = yaml.load(workflow_path)
-    workflow["jobs"]["test"]["strategy"]["matrix"]["kubernetes-version"][0] = versions[
+    latest_kind_container = versions[0]["latest_kind_container"]
+    if "minimal-deps" in workflow["jobs"]:
+        workflow["jobs"]["minimal-deps"]["strategy"]["matrix"]["kubernetes-version"][
+            0
+        ] = latest_kind_container
+    workflow["jobs"]["test"]["strategy"]["matrix"]["kubernetes-version"][
         0
-    ]["latest_kind_container"]
+    ] = latest_kind_container
     workflow["jobs"]["test"]["strategy"]["matrix"]["include"] = []
     for version in versions[1:]:
         workflow["jobs"]["test"]["strategy"]["matrix"]["include"].append(


### PR DESCRIPTION
In #516 we found a case where we were missing the `typing-extensions` dependency when installing `kr8s` in a fresh environment. It's likely that this wasn't caught in CI because `pytest` or another test dependency depends on that package.

This PR adds a minimal workflow that installs `kr8s` in a fresh Python environment and runs a quick smoke test to ensure that minimal dependencies are installed.