### PR TITLE
Add support for pagination

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -13,7 +13,6 @@ from typing import (
     BinaryIO,
     List,
     Literal,
-    Sequence,
     cast,
 )
 
@@ -255,25 +254,31 @@ class APIObject:
         while start + timeout > time.time():
             if name:
                 try:
-                    resources = await api.async_get(
-                        cls,
-                        name,
-                        namespace=namespace,
-                        field_selector={"metadata.name": name},
-                        **kwargs,
-                    )
+                    resources = [
+                        resource
+                        async for resource in api.async_get(
+                            cls,
+                            name,
+                            namespace=namespace,
+                            field_selector={"metadata.name": name},
+                            **kwargs,
+                        )
+                    ]
                 except ServerError as e:
                     if e.response and e.response.status_code == 404:
                         continue
                     raise e
             elif label_selector or field_selector:
-                resources = await api.async_get(
-                    cls,
-                    namespace=namespace,
-                    label_selector=label_selector,
-                    field_selector=field_selector,
-                    **kwargs,
-                )
+                resources = [
+                    resource
+                    async for resource in api.async_get(
+                        cls,
+                        namespace=namespace,
+                        label_selector=label_selector,
+                        field_selector=field_selector,
+                        **kwargs,
+                    )
+                ]
             else:
                 raise ValueError("Must specify name or selector")
             if not isinstance(resources, list):
@@ -689,7 +694,7 @@ class APIObject:
 
     # Must be the last method defined due to https://github.com/python/mypy/issues/17517
     @classmethod
-    async def list(cls, **kwargs) -> Sequence[Self]:
+    async def list(cls, **kwargs) -> AsyncGenerator[Self]:
         """List objects in Kubernetes.
 
         Args:
@@ -699,10 +704,9 @@ class APIObject:
             A list of objects.
         """
         api = await kr8s.asyncio.api()
-        resources = await api.async_get(kind=cls, **kwargs)
-        if not isinstance(resources, list):
-            resources = [resources]
-        return [resource for resource in resources if isinstance(resource, cls)]
+        async for resource in api.async_get(kind=cls, **kwargs):
+            if isinstance(resource, cls):
+                yield resource
 
 
 ## v1 objects
@@ -1338,11 +1342,14 @@ class Service(APIObject):
     async def async_ready_pods(self) -> list[Pod]:
         """Return a list of ready Pods for this Service."""
         assert self.api
-        pods = await self.api.async_get(
-            "pods",
-            label_selector=dict_to_selector(self.spec["selector"]),
-            namespace=self.namespace,
-        )
+        pods = [
+            pod
+            async for pod in self.api.async_get(
+                "pods",
+                label_selector=dict_to_selector(self.spec["selector"]),
+                namespace=self.namespace,
+            )
+        ]
         if isinstance(pods, Pod):
             pods = [pods]
         elif isinstance(pods, List) and all(isinstance(pod, Pod) for pod in pods):
@@ -1453,11 +1460,14 @@ class Deployment(APIObject):
     async def pods(self) -> list[Pod]:
         """Return a list of Pods for this Deployment."""
         assert self.api
-        pods = await self.api.async_get(
-            "pods",
-            label_selector=dict_to_selector(self.spec["selector"]["matchLabels"]),
-            namespace=self.namespace,
-        )
+        pods = [
+            pod
+            async for pod in self.api.async_get(
+                "pods",
+                label_selector=dict_to_selector(self.spec["selector"]["matchLabels"]),
+                namespace=self.namespace,
+            )
+        ]
         if isinstance(pods, Pod):
             return [pods]
         if isinstance(pods, List) and all(isinstance(pod, Pod) for pod in pods):

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -55,7 +55,7 @@ async def get(
     """
     if api is None:
         api = await _api(_asyncio=_asyncio)
-    return await api.async_get(
+    async for resource in api.async_get(
         kind,
         *names,
         namespace=namespace,
@@ -64,7 +64,8 @@ async def get(
         as_object=as_object,
         allow_unknown_type=allow_unknown_type,
         **kwargs,
-    )
+    ):
+        yield resource
 
 
 async def version(api=None, _asyncio=True):

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -146,7 +146,7 @@ async def kubeconfig_with_certs_on_disk(k8s_cluster):
 
 async def test_kubeconfig(k8s_cluster):
     api = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
     assert await api.whoami() == "kubernetes-admin"
 
 
@@ -155,7 +155,7 @@ async def test_kubeconfig_multi_paths_same(k8s_cluster):
         f"{k8s_cluster.kubeconfig_path}:{k8s_cluster.kubeconfig_path}"
     )
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_multi_str)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
     assert await api.whoami() == "kubernetes-admin"
 
 
@@ -164,7 +164,7 @@ async def test_kubeconfig_multi_paths_diff(k8s_cluster, tmp_path):
     kubeconfig2 = Path(tmp_path / "kubeconfig").write_bytes(kubeconfig1.read_bytes())
     kubeconfig_multi_str = f"{kubeconfig1}:{kubeconfig2}"
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_multi_str)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
     assert await api.whoami() == "kubernetes-admin"
 
 
@@ -172,7 +172,7 @@ async def test_kubeconfig_dict(k8s_cluster):
     config = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
     assert isinstance(config, dict)
     api = await kr8s.asyncio.api(kubeconfig=config)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
     assert await api.whoami() == "kubernetes-admin"
 
 
@@ -188,7 +188,7 @@ async def test_kubeconfig_context(kubeconfig_with_second_context):
     kubeconfig_path, context_name = kubeconfig_with_second_context
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_path, context=context_name)
     assert api.auth.active_context == context_name
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 async def test_default_service_account(k8s_cluster):
@@ -201,7 +201,7 @@ async def test_default_service_account(k8s_cluster):
 async def test_reauthenticate(k8s_cluster):
     api = await kr8s.asyncio.api(kubeconfig=k8s_cluster.kubeconfig_path)
     await api.reauthenticate()
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 def test_reauthenticate_sync(k8s_cluster):
@@ -222,13 +222,13 @@ async def test_bad_auth(serviceaccount):
 
 async def test_url(kubectl_proxy):
     api = await kr8s.asyncio.api(url=kubectl_proxy)
-    assert await api.get("pods", namespace="kube-system")
+    assert await anext(api.get("pods", namespace="kube-system"))
     assert api.auth.server == kubectl_proxy
 
     # Ensure reauthentication works
     api.auth.server = None
     await api.reauthenticate()
-    assert await api.get("pods", namespace="kube-system")
+    assert await anext(api.get("pods", namespace="kube-system"))
     assert api.auth.server == kubectl_proxy
 
 
@@ -285,7 +285,7 @@ async def test_service_account_with_kubeconfig_namespace(serviceaccount):
 
 async def test_exec(kubeconfig_with_exec):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_exec)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
     assert api.auth.server
     assert api.auth.server_ca_file
 
@@ -300,24 +300,24 @@ async def test_exec(kubeconfig_with_exec):
 async def test_token(kubeconfig_with_token):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_token)
     assert await api.whoami() == "system:serviceaccount:default:pytest"
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 @pytest.mark.parametrize("absolute", [True, False])
 async def test_certs_on_disk(kubeconfig_with_certs_on_disk, absolute):
     with kubeconfig_with_certs_on_disk(absolute=absolute) as kubeconfig:
         api = await kr8s.asyncio.api(kubeconfig=kubeconfig)
-        assert await api.get("pods", namespace=kr8s.ALL)
+        assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 async def test_certs_not_encoded(kubeconfig_with_decoded_certs):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_decoded_certs)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 async def test_certs_with_encoded_line_breaks(kubeconfig_with_line_breaks_in_certs):
     api = await kr8s.asyncio.api(kubeconfig=kubeconfig_with_line_breaks_in_certs)
-    assert await api.get("pods", namespace=kr8s.ALL)
+    assert await anext(api.get("pods", namespace=kr8s.ALL))
 
 
 @pytest.mark.parametrize(

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -259,7 +259,7 @@ def test_pod_create_and_delete_sync(example_pod_spec):
 
 async def test_list_and_ensure():
     api = await kr8s.asyncio.api()
-    pods = await api.get("pods", namespace=kr8s.ALL)
+    pods = [pod async for pod in api.get("pods", namespace=kr8s.ALL)]
     assert len(pods) > 0
     for pod in pods:
         await pod.refresh()
@@ -397,7 +397,10 @@ async def test_label_selector(example_pod_spec, selector):
     await pod.create()
 
     api = await kr8s.asyncio.api()
-    pods = await api.get("pods", namespace=kr8s.ALL, label_selector=selector)
+    pods = [
+        pod
+        async for pod in api.get("pods", namespace=kr8s.ALL, label_selector=selector)
+    ]
     assert len(pods) >= 0
 
     await pod.delete()
@@ -408,14 +411,20 @@ async def test_field_selector(example_pod_spec):
     await pod.create()
 
     api = await kr8s.asyncio.api()
-    pods = await api.get(
-        "pods", namespace=kr8s.ALL, field_selector={"metadata.name": pod.name}
-    )
+    pods = [
+        pod
+        async for pod in api.get(
+            "pods", namespace=kr8s.ALL, field_selector={"metadata.name": pod.name}
+        )
+    ]
     assert len(pods) == 1
 
-    pods = await api.get(
-        "pods", namespace=kr8s.ALL, field_selector="metadata.name=" + "foo-bar-baz"
-    )
+    pods = [
+        pod
+        async for pod in api.get(
+            "pods", namespace=kr8s.ALL, field_selector="metadata.name=" + "foo-bar-baz"
+        )
+    ]
     assert len(pods) == 0
 
     await pod.delete()
@@ -639,7 +648,7 @@ async def test_deployment_scale(example_deployment_spec):
 
 async def test_node():
     api = await kr8s.asyncio.api()
-    nodes = await api.get("nodes")
+    nodes = [node async for node in api.get("nodes")]
     assert len(nodes) > 0
     for node in nodes:
         assert node.unschedulable is False
@@ -650,7 +659,7 @@ async def test_node():
 
 async def test_service_proxy():
     api = await kr8s.asyncio.api()
-    [service] = await api.get("services", "kubernetes")
+    service = await anext(api.get("services", "kubernetes"))
     assert service.name == "kubernetes"
     data = await service.proxy_http_get("/version", raise_for_status=False)
     assert isinstance(data, httpx.Response)
@@ -1048,8 +1057,8 @@ async def test_pod_errors(bad_pod_spec):
 
 
 async def test_pod_list():
-    pods1 = await kr8s.asyncio.get("pods", namespace=kr8s.ALL)
-    pods2 = await Pod.list(namespace=kr8s.ALL)
+    pods1 = [pod async for pod in kr8s.asyncio.get("pods", namespace=kr8s.ALL)]
+    pods2 = [pod async for pod in Pod.list(namespace=kr8s.ALL)]
     assert pods1 and pods2
     assert len(pods1) == len(pods2)
     assert all(isinstance(p, Pod) for p in pods1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Changelog = "https://github.com/kr8s-org/kr8s/releases"
 addopts = "-v --keep-cluster --durations=10 --cov=kr8s --cov-report term-missing --cov-report xml:coverage.xml --cov-report lcov"
 timeout = 300
 xfail_strict = true
-reruns = 3
+reruns = 0
 reruns_delay = 1
 asyncio_mode = "auto"
 


### PR DESCRIPTION
This PR makes use of pagination when listing resources. This is expecially useful when working with clusters with large numbers of resources.

As a consequence the `kr8s.get()` and `APIObject.list()` methods have been changed to generators instead of returning lists. This allows us to iterate over all the resources in a Kubernetes cluster without using large amounts of memory. However this is a breaking change.

