### PR TITLE
Use metadata.name filter on name for api.get

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -462,7 +462,7 @@ class Api:
                 field_selector=field_selector,
                 as_object=as_object,
                 allow_unknown_type=allow_unknown_type,
-                **kwargs
+                **kwargs,
             ):
                 yield resource
 

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -433,7 +433,9 @@ async def test_two_pods(example_pod_spec, ns):
 
     async_api = await kr8s.asyncio.api()
 
-    pods_api = [pod async for pod in async_api.get("Pod", pod1.name, pod2.name, namespace=ns)]
+    pods_api = [
+        pod async for pod in async_api.get("Pod", pod1.name, pod2.name, namespace=ns)
+    ]
     assert len(pods_api) == 2
 
     for pod in pods:


### PR DESCRIPTION
Closes https://github.com/kr8s-org/kr8s/issues/486

This PR:

1. Defines a new `_async_get_single` which queries the API for a specific name using a `metadata.name` filter. It also accepts `name=None` for cases where a name is not provided.
2. `async_get` now calls `_async_get_single` multiple times with different names. If no name is provided it just passes `None` as the name.
