### PR TITLE
Add taint function and taints property to Node

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -832,6 +832,7 @@ class Node(APIObject):
 
     async def taint(self, key: str, value: str, *, effect: str) -> None:
         """Taint a node."""
+        await self.async_refresh()
         if effect.endswith("-"):
             # Remove taint with key
             effect = effect[:-1]

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -661,7 +661,7 @@ async def test_node():
 
 async def test_node_taint():
     api = await kr8s.asyncio.api()
-    nodes = await api.get("nodes")
+    nodes = [node async for node in api.get("nodes")]
     assert len(nodes) > 0
     node = nodes[0]
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -665,6 +665,11 @@ async def test_node_taint():
     assert len(nodes) > 0
     node = nodes[0]
 
+    # Remove existing taints just in case they still exist
+    for taint in node.taints:
+        await node.taint(key=taint["key"], value=taint["value"], effect="NoSchedule-")
+    assert not node.taints
+
     await node.taint(key="key1", value="value1", effect="NoSchedule")
     await node.taint(key="key2", value="value2", effect="NoSchedule")
     assert len(node.taints) == 2

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -648,6 +648,21 @@ async def test_node():
         await node.uncordon()
 
 
+async def test_node_taint():
+    api = await kr8s.asyncio.api()
+    nodes = [node async for node in api.get("nodes")]
+    assert len(nodes) > 0
+    node = nodes[0]
+
+    await node.taint(key="key1", value="value1", effect="NoSchedule")
+    assert any(
+        taint["key"] == "key1" and taint["value"] == "value1" for taint in node.taints
+    )
+
+    await node.taint(key="key1", value="value1", effect="NoSchedule-")
+    assert not node.taints
+
+
 async def test_service_proxy():
     api = await kr8s.asyncio.api()
     [service] = await api.get("services", "kubernetes")


### PR DESCRIPTION
Addresses part of https://github.com/kr8s-org/kr8s/issues/326

This PR adds:

- A `taints` property, so `nodes.taints` gives you access to the taints.
- A `taint` function to add a taint
- A nice to have `effect="NoSchedule-"` that remove the taint. This is consistent with how `kubectl` works for removing a taint.