### PR TITLE
Upgrade kubectl-ng get to the new async syntax

### DIFF
--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -49,12 +49,15 @@ async def draw_table(kind, response, resource_names):
 async def get_resources(resources, label_selector, field_selector):
     data = {}
     for kind in resources:
-        data[kind] = await kr8s.asyncio.get(
-            kind,
-            label_selector=label_selector,
-            field_selector=field_selector,
-            as_object=Table,
-        )
+        data[kind] = [
+            resource
+            async for resource in kr8s.asyncio.get(
+                kind,
+                label_selector=label_selector,
+                field_selector=field_selector,
+                as_object=Table,
+            )
+        ]
     return data
 
 

--- a/examples/kubectl-ng/kubectl_ng/_get.py
+++ b/examples/kubectl-ng/kubectl_ng/_get.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.live import Live
 
 import kr8s
+from kr8s._async_utils import anext
 from kr8s.asyncio.objects import Table
 
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
@@ -49,15 +50,14 @@ async def draw_table(kind, response, resource_names):
 async def get_resources(resources, label_selector, field_selector):
     data = {}
     for kind in resources:
-        data[kind] = [
-            resource
-            async for resource in kr8s.asyncio.get(
+        data[kind] = await anext(
+            kr8s.asyncio.get(
                 kind,
                 label_selector=label_selector,
                 field_selector=field_selector,
                 as_object=Table,
             )
-        ]
+        )
     return data
 
 


### PR DESCRIPTION
Adopt the new async syntax from #523 in `kubectl-ng get`.