### PR TITLE
Bump minimum version of Python to 3.9 and httpx-ws to 0.7.0

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -4,12 +4,12 @@ on:
     paths:
       - ".github/workflows/test-kr8s.yaml"
       - "kr8s/**"
-      - "./pyproject.toml"
+      - "pyproject.toml"
   push:
     paths:
       - ".github/workflows/test-kr8s.yaml"
       - "kr8s/**"
-      - "./pyproject.toml"
+      - "pyproject.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         kubernetes-version: ["1.32.0"]
         include:
           - python-version: '3.10'
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         # Test the minimal and maximal Python versions only
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         kubernetes-version: ["1.32.0"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-kubectl-ng.yaml
+++ b/.github/workflows/test-kubectl-ng.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         kubernetes-version: ["1.32.0"]
         include:
           - python-version: '3.10'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Read the Docs](https://img.shields.io/readthedocs/kr8s?logo=readthedocs&logoColor=white)](https://docs.kr8s.org/en/stable/)
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
-[![Python Version Support](https://img.shields.io/badge/Python%20support-3.8%7C3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
+[![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
 [![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.29%7C1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
-[![Python Version Support](https://img.shields.io/badge/Python%20support-3.8%7C3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
+[![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
 [![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.29%7C1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "python-jsonpath>=0.7.1",
     "anyio>=3.7.0",
     "httpx>=0.24.1",
-    "httpx-ws>=0.5.2",
+    "httpx-ws>=0.7.0",
     "python-box>=7.0.1",
     "typing_extensions>=4.12.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 keywords = ["kubernetes", "kubectl"]
 license = { text = "BSD-3-Clause" }
 classifiers = ["Programming Language :: Python :: 3"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
     "asyncache>=0.3.1",


### PR DESCRIPTION
In #543 we are seeing an issue with the websocket ping conflicting with our interactions with the websocket. It looks like it was fixed upstream in https://github.com/frankie567/httpx-ws/pull/89 and released in `httpx-ws` version `0.7.0`.

This PR bumps our minimum version to ensure we get that fix.

This version of `httpx-ws` doesn't support Python 3.8 so this feels like a good opportunity to bump out minimum Python version to 3.9.

Closes #543 