### PR TITLE
Fix Custom Resource pagination hang

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -528,6 +528,7 @@ class Api:
                 if (
                     "metadata" in resourcelist
                     and "continue" in resourcelist["metadata"]
+                    and resourcelist["metadata"]["continue"]
                 ):
                     continue_paging = True
                     params["continue"] = resourcelist["metadata"]["continue"]


### PR DESCRIPTION
Follow on to #523 to close #544.

In #544 we are observing a hang when listing custom resources. It appears that built in resources omit the `continue` metadata parameter when reaching the end of the list, so we were testing for that to decide when to finish paging. However for custom resoureces it still includes the `continue` paratmeter but just returns an empty string. This was resulting in us paging forever.

This PR extends the check to ensure the `continue` parameter contains a value. I've also added come fixtures to make it easier to create and test custom resources in the future.