### PR TITLE
Pass kwargs along in `APIObjectSyncMixin.list()`

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -834,8 +834,8 @@ class APIObjectSyncMixin(APIObject):
         return run_sync(self.async_adopt)(child)  # type: ignore
 
     @classmethod
-    def list(cls):
-        yield from run_sync(cls.async_list)()
+    def list(cls, **kwargs):
+        yield from run_sync(cls.async_list)(**kwargs)
 
 
 ## v1 objects

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1144,8 +1144,8 @@ async def test_pod_list_sync():
     pods2 = [pod for pod in SyncPod.list(namespace=kr8s.ALL)]
     assert pods1 and pods2
     assert len(pods1) == len(pods2)
-    assert all(isinstance(p, Pod) for p in pods1)
-    assert all(isinstance(p, Pod) for p in pods2)
+    assert all(isinstance(p, SyncPod) for p in pods1)
+    assert all(isinstance(p, SyncPod) for p in pods2)
     assert {p.name for p in pods1} == {p.name for p in pods2}
 
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1139,6 +1139,16 @@ async def test_pod_list():
     assert {p.name for p in pods1} == {p.name for p in pods2}
 
 
+async def test_pod_list_sync():
+    pods1 = [pod for pod in kr8s.get("pods", namespace=kr8s.ALL)]
+    pods2 = [pod for pod in SyncPod.list(namespace=kr8s.ALL)]
+    assert pods1 and pods2
+    assert len(pods1) == len(pods2)
+    assert all(isinstance(p, Pod) for p in pods1)
+    assert all(isinstance(p, Pod) for p in pods2)
+    assert {p.name for p in pods1} == {p.name for p in pods2}
+
+
 @pytest.mark.parametrize(
     "ports",
     [


### PR DESCRIPTION
Fixed regression reported in #553 

Closes #553 