### PR TITLE
Fix type hint on sync `api.get()`

### DIFF
--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -77,7 +77,7 @@ class Api(_AsyncApi):
         as_object: type[APIObject] | None = None,
         allow_unknown_type: bool = True,
         **kwargs,
-    ) -> Generator[APIObject]:
+    ) -> Generator[objects.APIObject]:
         yield from _run_sync(self.async_get)(
             kind,
             *names,
@@ -96,7 +96,7 @@ class Api(_AsyncApi):
         label_selector: str | dict | None = None,
         field_selector: str | dict | None = None,
         since: str | None = None,
-    ) -> Generator[tuple[str, APIObject]]:
+    ) -> Generator[tuple[str, objects.APIObject]]:
         yield from _run_sync(self.async_watch)(
             kind,
             namespace=namespace,

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -138,6 +138,10 @@ from ._objects import objects_from_files as _objects_from_files
 from .portforward import PortForward
 
 
+class APIObject(APIObjectSyncMixin):
+    __doc__ = APIObjectSyncMixin.__doc__
+
+
 class Binding(APIObjectSyncMixin, _Binding):
     __doc__ = _Binding.__doc__
 

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -265,14 +265,17 @@ async def test_async_get_returns_async_objects() -> None:
 
 
 def test_sync_get_returns_sync_objects() -> None:
-    pods = kr8s.get("pods", namespace=kr8s.ALL)
-    assert list(pods)[0]._asyncio is False
+    pods = list(kr8s.get("pods", namespace=kr8s.ALL))
+    assert pods[0]._asyncio is False
+    pods[0].refresh()
 
 
 def test_sync_api_returns_sync_objects():
     api = kr8s.api()
     pods = api.get("pods", namespace=kr8s.ALL)
-    assert next(pods)._asyncio is False
+    pod = next(pods)
+    assert pod._asyncio is False
+    pod.refresh()
 
 
 async def test_api_names(example_pod_spec: dict, ns: str) -> None:


### PR DESCRIPTION
The return type for the sync implementation of `api.get()` was effectively `Generator[kr8s.asyncio.objects.APIObject, None, None]`. This PR fixes it to be the sync base class shim `Generator[kr8s.objects.APIObject, None, None]`.

I had to reinstate the sync base class that was removed in https://github.com/kr8s-org/kr8s/pull/551#discussion_r1915161783 for type hinting purposes.

Closes #555 