### PR TITLE
Allow overriding of sync shims in Service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: 'v1.14.1'
     hooks:
     - id: mypy
-      exclude: "examples|venv|ci|docs|conftest.py"
+      exclude: "examples|venv|ci|docs"
       additional_dependencies: [types-pyyaml>=6.0]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -281,12 +281,12 @@ class ServiceAccount(APIObjectSyncMixin, _ServiceAccount):
 
 
 class Service(APIObjectSyncMixin, _Service):
-    def proxy_http_request(
+    def proxy_http_request(  # type: ignore
         self, method: str, path: str, port: int | None = None, **kwargs: Any
     ) -> httpx.Response:
         return run_sync(self.async_proxy_http_request)(method, path, port=port, **kwargs)  # type: ignore
 
-    def proxy_http_get(
+    def proxy_http_get(  # type: ignore
         self, path: str, port: int | None = None, **kwargs
     ) -> httpx.Response:
         return run_sync(self.async_proxy_http_request)("GET", path, port, **kwargs)  # type: ignore
@@ -294,12 +294,12 @@ class Service(APIObjectSyncMixin, _Service):
     def proxy_http_post(self, path: str, port: int | None = None, **kwargs) -> None:  # type: ignore
         return run_sync(self.async_proxy_http_request)("POST", path, port, **kwargs)  # type: ignore
 
-    def proxy_http_put(
+    def proxy_http_put(  # type: ignore
         self, path: str, port: int | None = None, **kwargs
     ) -> httpx.Response:
         return run_sync(self.async_proxy_http_request)("PUT", path, port, **kwargs)  # type: ignore
 
-    def proxy_http_delete(
+    def proxy_http_delete(  # type: ignore
         self, path: str, port: int | None = None, **kwargs
     ) -> httpx.Response:
         return run_sync(self.async_proxy_http_request)("DELETE", path, port, **kwargs)  # type: ignore


### PR DESCRIPTION
Running `mypy kr8s` locally complained about these overrides. Not sure why the pre-commit mypy didn't catch this.