### PR TITLE
Allow passing `api` kwarg to `APIObject.list()`

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -746,8 +746,12 @@ class APIObject:
         raise NotImplementedError("gen is not implemented for this object")
 
     @classmethod
-    async def async_list(cls, **kwargs) -> AsyncGenerator[Self]:
-        api = await kr8s.asyncio.api()
+    async def async_list(cls, api: Api | None = None, **kwargs) -> AsyncGenerator[Self]:
+        if api is None:
+            if cls._asyncio:
+                api = await kr8s.asyncio.api()
+            else:
+                api = await kr8s.asyncio.api(_asyncio=False)
         async for resource in api.async_get(kind=cls, **kwargs):
             if isinstance(resource, cls):
                 yield resource
@@ -758,6 +762,7 @@ class APIObject:
         """List objects in Kubernetes.
 
         Args:
+            api: An optional API object to use.
             **kwargs: Keyword arguments to pass to :func:`kr8s.get`.
 
         Returns:

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1139,7 +1139,7 @@ async def test_pod_list():
     assert {p.name for p in pods1} == {p.name for p in pods2}
 
 
-async def test_pod_list_sync():
+def test_pod_list_sync():
     pods1 = [pod for pod in kr8s.get("pods", namespace=kr8s.ALL)]
     pods2 = [pod for pod in SyncPod.list(namespace=kr8s.ALL)]
     assert pods1 and pods2
@@ -1147,6 +1147,24 @@ async def test_pod_list_sync():
     assert all(isinstance(p, SyncPod) for p in pods1)
     assert all(isinstance(p, SyncPod) for p in pods2)
     assert {p.name for p in pods1} == {p.name for p in pods2}
+
+
+async def test_pod_list_api():
+    api = await kr8s.asyncio.api()
+    pods = [pod async for pod in Pod.list(namespace=kr8s.ALL, api=api)]
+    assert pods
+    assert pods[0].api
+    assert pods[0].api == api
+    assert pods[0].api._asyncio
+
+
+async def test_pod_list_api_sync():
+    api = kr8s.api()
+    pods = [pod for pod in SyncPod.list(namespace=kr8s.ALL, api=api)]
+    assert pods
+    assert pods[0].api
+    assert pods[0].api == api
+    assert not pods[0].api._asyncio
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Allow passing `api` kwarg to `APIObject.list()` in the same way you can to `APIObject.get()`.

```python
import kr8s

api = kr8s.api()
pods = kr8s.objects.Pod.list(api=api)
```

Closes #560 