### PR TITLE
Add `force` and `grace_period_seconds` options to delete

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -389,6 +389,8 @@ class APIObject:
         data: dict[str, Any] = {}
         if propagation_policy:
             data["propagationPolicy"] = propagation_policy
+        if grace_period and force:
+            raise ValueError("Cannot set both grace_period and force")
         if grace_period:
             data["gracePeriodSeconds"] = grace_period
         elif force:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -363,34 +363,34 @@ class APIObject:
     async def delete(
         self,
         propagation_policy: str | None = None,
-        grace_period_seconds: int | None = None,
+        grace_period: int | None = None,
         force: bool = False,
     ) -> None:
         """Delete this object from Kubernetes.
 
         Args:
             propagation_policy: The deletion propagation policy.
-            grace_period_seconds: The grace period for deletion.
-            force: Force deletion. (Setting to ``True`` is equivelaent to setting grace_period_seconds to 0)
+            grace_period: The grace period for deletion.
+            force: Force deletion. (Setting to ``True`` is equivelaent to setting grace_period to 0)
         """
         return await self.async_delete(
             propagation_policy=propagation_policy,
-            grace_period_seconds=grace_period_seconds,
+            grace_period=grace_period,
             force=force,
         )
 
     async def async_delete(
         self,
         propagation_policy: str | None = None,
-        grace_period_seconds: int | None = None,
+        grace_period: int | None = None,
         force: bool = False,
     ) -> None:
         """Delete this object from Kubernetes."""
         data: dict[str, Any] = {}
         if propagation_policy:
             data["propagationPolicy"] = propagation_policy
-        if grace_period_seconds:
-            data["gracePeriodSeconds"] = grace_period_seconds
+        if grace_period:
+            data["gracePeriodSeconds"] = grace_period
         elif force:
             data["gracePeriodSeconds"] = 0
         try:
@@ -829,12 +829,12 @@ class APIObjectSyncMixin(APIObject):
     def delete(  # type: ignore[override]
         self,
         propagation_policy: str | None = None,
-        grace_period_seconds: int | None = None,
+        grace_period: int | None = None,
         force: bool = False,
     ) -> None:
         run_sync(self.async_delete)(
             propagation_policy=propagation_policy,
-            grace_period_seconds=grace_period_seconds,
+            grace_period=grace_period,
             force=force,
         )  # type: ignore
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -128,6 +128,26 @@ async def test_pod_create_and_delete(example_pod_spec):
     assert not await pod.exists()
 
 
+async def test_pod_force_delete(example_pod_spec):
+    pod = await Pod(example_pod_spec)
+    await pod.create()
+    while not await pod.exists():
+        await anyio.sleep(0.1)
+    await pod.delete(force=True)
+    await anyio.sleep(0.1)
+    assert not await pod.exists()
+
+
+def test_pod_force_delete_sync(example_pod_spec):
+    pod = SyncPod(example_pod_spec)
+    pod.create()
+    while not pod.exists():
+        time.sleep(0.1)
+    pod.delete(force=True)
+    time.sleep(0.1)
+    assert not pod.exists()
+
+
 async def test_pod_object_from_name_type(example_pod_spec):
     pod = await Pod(example_pod_spec)
     await pod.create()
@@ -152,7 +172,7 @@ async def test_pod_wait_ready(example_pod_spec):
     await pod.wait("jsonpath='{.status.phase}'=Running")
     with pytest.raises(ValueError):
         await pod.wait("foo=NotARealCondition")
-    await pod.delete()
+    await pod.delete(grace_period_seconds=10)
     await pod.wait("condition=Ready=False")
     await pod.wait("delete")
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -172,7 +172,7 @@ async def test_pod_wait_ready(example_pod_spec):
     await pod.wait("jsonpath='{.status.phase}'=Running")
     with pytest.raises(ValueError):
         await pod.wait("foo=NotARealCondition")
-    await pod.delete(grace_period_seconds=10)
+    await pod.delete(grace_period=10)
     await pod.wait("condition=Ready=False")
     await pod.wait("delete")
 


### PR DESCRIPTION
Closes #564 

Allows setting the `gracePeriodSeconds` API paramater for `DELETE` operations. This PR exposes this either as a `grace_period` kwarg which can be set to an integer, or a `delete` kwarg which can be set to `True`. 

These match the `--grace-period` and `--force` flags in `kubectl delete <resource>`.

```python
# Delete the Pod with a grace period of 10 seconds
pod.delete(grace_period=10) 

# Delete the Pod immediately
pod.delete(force=True)

# Equivalent delete the Pod immediately
pod.delete(grace_period=0)
```