### PR TITLE
fix: avoid unread streaming response error

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -158,7 +158,10 @@ class Api:
                 if stream:
                     assert self._session
                     async with self._session.stream(**kwargs) as response:
-                        if raise_for_status:
+                        if response.is_error and raise_for_status:
+                            # NOTE: Avoid `httpx.ResponseNotRead` w/ streaming requests
+                            # https://github.com/encode/httpx/discussions/1856#discussioncomment-1316674
+                            await response.aread()
                             response.raise_for_status()
                         yield response
                 else:


### PR DESCRIPTION
This patch ensures that when Pod logs are streamed and an error occurs with the k8s API, that kr8s will properly raise the http response instead of raising `httpx.ResponseNotRead`

fixes: #573

I was not able to create a good test case for this outside of my application, but in my own experience dealing with a k8s API exception in my cluster (due to other buggy logic in my application) I have noticed an improvement in the exception handling due to this fix

---

Before:
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/kr8s/_api.py", line 162, in call_api
    response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://10.43.0.1/api/v1/namespaces/****/pods/****/log?pretty=true&timestamps=true'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  ...
  File "/app/app/main.py", line 397, in logs_gen
    async for log in pod.logs(since_time=start_time, follow=follow):
  File "/usr/local/lib/python3.11/site-packages/kr8s/_objects.py", line 1098, in logs
    async for line in self.async_logs(
  File "/usr/local/lib/python3.11/site-packages/kr8s/_objects.py", line 1193, in async_logs
    async with self.api.call_api(
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kr8s/_api.py", line 184, in call_api
    error = e.response.json()
            ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 766, in json
    return jsonlib.loads(self.content, **kwargs)
                         ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 572, in content
    raise ResponseNotRead()
httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```

After:
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/kr8s/_api.py", line 165, in call_api
    response.raise_for_status()
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://10.43.0.1/api/v1/namespaces/****/pods/****/log?pretty=true&timestamps=true'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
  File "/app/app/main.py", line 397, in logs_gen
    async for log in pod.logs(since_time=start_time, follow=follow):
  File "/usr/local/lib/python3.11/site-packages/kr8s/_objects.py", line 1098, in logs
    async for line in self.async_logs(
  File "/usr/local/lib/python3.11/site-packages/kr8s/_objects.py", line 1193, in async_logs
    async with self.api.call_api(
  File "/usr/local/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kr8s/_api.py", line 192, in call_api
    raise ServerError(
kr8s._exceptions.ServerError: container "****" in pod "****" is waiting to start: image can't be pulled
```