### PR TITLE
Out of curiosity, how backward compatible are things?

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,6 +29,18 @@ jobs:
             kubernetes-version: 1.31.6
           - python-version: '3.10'
             kubernetes-version: 1.30.10
+          - python-version: '3.10'
+            kubernetes-version: 1.29.14
+          - python-version: '3.10'
+            kubernetes-version: 1.28.15
+          - python-version: '3.10'
+            kubernetes-version: 1.27.16
+          - python-version: '3.10'
+            kubernetes-version: 1.26.15
+          - python-version: '3.10'
+            kubernetes-version: 1.25.16
+          - python-version: '3.10'
+            kubernetes-version: 1.24.17
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/test-kubectl-ng.yaml
+++ b/.github/workflows/test-kubectl-ng.yaml
@@ -27,6 +27,18 @@ jobs:
             kubernetes-version: 1.31.6
           - python-version: '3.10'
             kubernetes-version: 1.30.10
+          - python-version: '3.10'
+            kubernetes-version: 1.29.14
+          - python-version: '3.10'
+            kubernetes-version: 1.28.15
+          - python-version: '3.10'
+            kubernetes-version: 1.27.16
+          - python-version: '3.10'
+            kubernetes-version: 1.26.15
+          - python-version: '3.10'
+            kubernetes-version: 1.25.16
+          - python-version: '3.10'
+            kubernetes-version: 1.24.17
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.24%7C1.25%7C1.26%7C1.27%7C1.28%7C1.29%7C1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -32,7 +32,8 @@ def get_kubernetes_oss_versions():
                 "eol": datetime.strptime(x["eol"], DATE_FORMAT),
             }
             for x in data
-            if datetime.strptime(x["eol"], DATE_FORMAT) > datetime.now()
+            if datetime.strptime(x["eol"], DATE_FORMAT)
+            > (datetime.now() - timedelta(weeks=52 * 2))
         ]
         data.sort(key=lambda x: x["eol"], reverse=True)
     return data

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.24%7C1.25%7C1.26%7C1.27%7C1.28%7C1.29%7C1.30%7C1.31%7C1.32-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 <iframe src="https://ghbtns.com/github-btn.html?user=kr8s-org&repo=kr8s&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -588,6 +588,21 @@ async def test_all_v1_objects_represented():
         assert get_class(obj["kind"], obj["version"])
 
 
+@pytest.mark.parametrize(
+    "name, object_class",
+    [
+        ("pods", Pod),
+        ("services", Service),
+        ("configmaps", ConfigMap),
+        ("nodes", Node),
+    ],
+)
+def test_object_resolver(name, object_class):
+    api = kr8s.api()
+    for obj in api.get(name):
+        assert isinstance(obj, object_class)
+
+
 async def test_object_from_spec(example_pod_spec, example_service_spec):
     pod = object_from_spec(example_pod_spec)
     assert isinstance(pod, Pod)


### PR DESCRIPTION
Yesterday I used `kr8s==0.20.6` (which supports Kubernetes `1.30+`) on a Kubernetes `1.26` cluster and things mostly worked, but there were a few weird edge cases.

Out of curiosity I'm interested to see how far back we can go and have tests still pass.

**This does not signal our intention to change [the way we calculate which versions we support](https://docs.kr8s.org/en/latest/installation.html#supported-kubernetes-versions). I'm just curious and the easiest way to test it out is to open a PR and let CI run.**