### PR TITLE
Add `APIObject.to_yaml()` and `APIObject.pprint()`

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -781,17 +781,13 @@ class APIObject:
             theme: The pygments theme to use. Defaults to "ansi_dark" to use default terminal colors.
 
         """
-        yaml_output = self.to_yaml()
         if use_rich:
-            try:
+            with contextlib.suppress(ImportError):
                 from rich import print as rich_print
                 from rich.syntax import Syntax
 
-                yaml_output = Syntax(code=yaml_output, lexer="yaml", theme=theme)
-                rich_print(yaml_output)
+                rich_print(Syntax(code=self.to_yaml(), lexer="yaml", theme=theme))
                 return
-            except ImportError:
-                pass
         print(self.to_yaml())
 
     @classmethod

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -774,11 +774,11 @@ class APIObject:
     def pprint(self, use_rich: bool = True, theme: str = "ansi_dark") -> None:
         """Pretty print this object to stdout.
 
-        Prints the object as YAML using ``rich`` if available.
+        Prints the object as YAML (using ``rich`` for syntax highlighting if available).
 
         Args:
-            use_rich: Use ``rich`` to pretty print.
-            theme: The pygments theme to use. Defaults to "ansi_dark" to use default terminal colors.
+            use_rich: Use ``rich`` to pretty print. If ``rich` is not installed this will be ignored.
+            theme: The ``pygments`` theme for ``rich`` to use. Defaults to "ansi_dark" to use default terminal colors.
 
         """
         if use_rich:

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -725,6 +725,10 @@ class APIObject:
         """Return a dictionary representation of this object."""
         return self.raw.to_dict()
 
+    def to_yaml(self) -> str:
+        """Return a YAML representation of this object."""
+        return yaml.dump(self.to_dict())
+
     def to_lightkube(self) -> Any:
         """Return a lightkube representation of this object."""
         try:
@@ -766,6 +770,29 @@ class APIObject:
                 {"version": self.version, "endpoint": self.endpoint, "kind": self.kind},
             )
         return pykube_cls(api, self.raw)
+
+    def pprint(self, use_rich: bool = True, theme: str = "ansi_dark") -> None:
+        """Pretty print this object to stdout.
+
+        Prints the object as YAML using ``rich`` if available.
+
+        Args:
+            use_rich: Use ``rich`` to pretty print.
+            theme: The pygments theme to use. Defaults to "ansi_dark" to use default terminal colors.
+
+        """
+        yaml_output = self.to_yaml()
+        if use_rich:
+            try:
+                from rich import print as rich_print
+                from rich.syntax import Syntax
+
+                yaml_output = Syntax(code=yaml_output, lexer="yaml", theme=theme)
+                rich_print(yaml_output)
+                return
+            except ImportError:
+                pass
+        print(self.to_yaml())
 
     @classmethod
     def gen(cls, *args, **kwargs):

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -12,6 +12,7 @@ from contextlib import suppress
 import anyio
 import httpx
 import pytest
+import yaml
 
 import kr8s
 from kr8s._async_utils import anext
@@ -954,6 +955,12 @@ async def test_pod_to_dict(example_pod_spec):
     pod = Pod(example_pod_spec)
     assert dict(pod) == example_pod_spec
     assert dict(pod) == pod.raw
+
+
+async def test_pod_to_yaml(example_pod_spec):
+    pod = Pod(example_pod_spec)
+    assert f"name: {pod.name}" in pod.to_yaml()
+    assert yaml.safe_load(pod.to_yaml()) == example_pod_spec
 
 
 async def test_adoption(nginx_service):


### PR DESCRIPTION
Add a built-in `APIObject.to_yaml()` method for dumping an object to YAML.
Add a `APIObject.pprint()` method to pretty print the YAML output, use `rich` for highlighting if installed.

Closes #585 