### PR TITLE
Adds an exec() method for any object with a ready_pods() method

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -7,6 +7,7 @@ import json
 import pathlib
 import re
 import time
+import warnings
 from collections.abc import AsyncGenerator, Generator
 from typing import (
     Any,
@@ -482,6 +483,56 @@ class APIObject:
         while self.replicas != replicas:
             await self.async_refresh()
             await anyio.sleep(0.1)
+
+    async def exec(
+        self,
+        command: list[str],
+        *,
+        container: str | None = None,
+        stdin: str | BinaryIO | None = None,
+        stdout: BinaryIO | None = None,
+        stderr: BinaryIO | None = None,
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> Exec:
+        """Execute a command in this object."""
+        return await self.async_exec(
+            command,
+            container=container,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            check=check,
+            capture_output=capture_output,
+        )
+
+    async def async_exec(
+        self,
+        command: list[str],
+        *,
+        container: str | None = None,
+        stdin: str | BinaryIO | None = None,
+        stdout: BinaryIO | None = None,
+        stderr: BinaryIO | None = None,
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> Exec:
+        """Execute a command in this object."""
+        if not hasattr(self, "ready_pods"):
+            raise NotImplementedError(f"{self.kind} does not support exec")
+        pods: list[Pod] = await self.ready_pods()
+        if not pods:
+            raise RuntimeError("No ready pods found")
+        pod = pods[0]
+        return await pod.async_exec(
+            command,
+            container=container,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            check=check,
+            capture_output=capture_output,
+        )
 
     async def async_watch(self) -> AsyncGenerator[tuple[str, Self]]:
         """Watch this object in Kubernetes."""
@@ -1808,11 +1859,11 @@ class Deployment(APIObject):
     namespaced = True
     scalable = True
 
-    async def pods(self) -> list[Pod]:
+    async def ready_pods(self) -> list[Pod]:
         """Return a list of Pods for this Deployment."""
         return await self.async_pods()
 
-    async def async_pods(self) -> list[Pod]:
+    async def async_ready_pods(self) -> list[Pod]:
         assert self.api
         pods = [
             pod
@@ -1829,6 +1880,19 @@ class Deployment(APIObject):
             # correctly in pyright so we need to explicitly use cast
             return cast(list[Pod], pods)
         raise TypeError(f"Unexpected type {type(pods)} returned from API")
+
+    async def pods(self) -> list[Pod]:
+        """Return a list of Pods for this Deployment."""
+        warnings.warn(
+            "pods() is deprecated, use ready_pods() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self.async_ready_pods()
+
+    async def async_pods(self) -> list[Pod]:
+        """Return a list of Pods for this Deployment."""
+        return await self.async_ready_pods()
 
     async def ready(self):
         """Check if the deployment is ready."""

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1114,6 +1114,23 @@ async def test_pod_exec_not_ready(ns):
         await pod.delete()
 
 
+async def test_service_exec(nginx_service):
+    ex = await nginx_service.exec(["date"])
+    assert isinstance(ex, CompletedExec)
+    assert str(datetime.datetime.now().year) in ex.stdout.decode()
+    assert ex.args == ["date"]
+    assert ex.stderr == b""
+    assert ex.returncode == 0
+
+
+async def test_configmap_exec_raises():
+    cm = await ConfigMap(
+        {"metadata": {"name": "nginx", "namespace": "default"}, "data": {"foo": "bar"}}
+    )
+    with pytest.raises(NotImplementedError):
+        await cm.exec(["date"])
+
+
 async def test_configmap_data(ns):
     [cm] = await objects_from_files(CURRENT_DIR / "resources" / "configmap.yaml")
     assert isinstance(cm, ConfigMap)


### PR DESCRIPTION
Closes #600

Added a generic `exec()` method to the `APIObject` base class. It checks for a `ready_pods()` method, if it doesn't exist it raises a `NotImplementedError`. If it does exist it gets the first Pod from `ready_pods()` and then calls `exec()` on that `Pod` passing the args/kwargs along.

Also added a `ready_pods()` method to `Deployment` which applied a ready filter to the existing `pods()` method.