### PR TITLE
Ensure minimal deps test exercises code

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -72,4 +72,4 @@ jobs:
       - name: Install kr8s
         run: pip install -e .
       - name: Ensure kr8s works
-        run: python -c "import kr8s; print(kr8s.get('nodes'))"
+        run: python -c "import kr8s; print(list(kr8s.get('nodes')))"


### PR DESCRIPTION
I noticed this morning that the generator changes in #551 mean that the minimal deps check doesn't actually exercise any code because it just prints the generator. This small PR just ensures the generator gets exhausted and therefore exercises the code.