### PR TITLE
Experiment with using an LLM to generate PR titles

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,8 +29,6 @@ jobs:
             kubernetes-version: 1.32.3
           - python-version: '3.10'
             kubernetes-version: 1.31.6
-          - python-version: '3.10'
-            kubernetes-version: 1.30.10
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/test-kubectl-ng.yaml
+++ b/.github/workflows/test-kubectl-ng.yaml
@@ -27,8 +27,6 @@ jobs:
             kubernetes-version: 1.32.3
           - python-version: '3.10'
             kubernetes-version: 1.31.6
-          - python-version: '3.10'
-            kubernetes-version: 1.30.10
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron:  '30 2 * * *'
   workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/update-kubernetes.yaml
+      - ci/update-kubernetes.py
 
 jobs:
   update-kubernetes:
@@ -18,14 +22,37 @@ jobs:
       - name: Update Kubernetes
         run: ./ci/update-kubernetes.py
       - name: Show diff
-        run: git diff
+        id: diff
+        run: |
+          echo 'diff<<EOF' >> $GITHUB_OUTPUT
+          git diff | tee -a $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+      - name: Generate PR title
+        uses: ai-action/ollama-action@v1
+        id: title-llm
+        with:
+          model: llama3.2
+          prompt: |
+            Generate a PR title for the following changes:
+
+            ```
+            ${{ steps.diff.outputs.diff }}
+            ```
+            The title should be concise and to the point, and should not include any markdown formatting.
+            The title should be in the format of "Update Kubernetes version: remove 1.27" or similar.
+            The title should be no more than 50 characters.
+            The title should be in the present tense.
+            The title is:
+      - name: Show PR title
+        run: |
+          echo "The action would generate the following PR title: ${{ steps.title-llm.outputs.response }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
-        if: github.repository == 'kr8s-org/kr8s'
+        if: github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
         with:
           base: main
-          commit-message: "Update Kubernetes versions"
-          title: "Update Kubernetes versions"
+          commit-message: ${{ steps.title-llm.outputs.response }}
+          title: ${{ steps.title-llm.outputs.response }}
           reviewers: "jacobtomlinson"
           token: "${{ secrets.BOT_TOKEN }}"
           labels: |

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -44,10 +44,13 @@ jobs:
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
-            Please generate a PR title for the following changes:
+            Here is a diff of the changes:
+            
             ```
             ${{ steps.diff.outputs.diff }}
             ```
+            Please generate a PR title with particular attention to the Kubernetes version that is being updated.
+
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'
         run: |

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -51,8 +51,6 @@ jobs:
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
-            ${{ steps.diff.outputs.diff }}
-
             Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
             Don't include the Python version information in the title or which files are being edited. Focus only on the Kubernetes version.
 

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -27,8 +27,13 @@ jobs:
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
           git diff | tee -a $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
+      - name: Check if PR is needed
+        id: pr-needed
+        run: |
+          echo "has_changes=$([[ ! -z "${{ steps.diff.outputs.diff }}" ]] && echo "true" || echo "false")" >> $GITHUB_OUTPUT
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
+        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true'
         id: title-llm
         with:
           model: llama3.2
@@ -44,11 +49,12 @@ jobs:
             The title should be in the present tense.
             The title is:
       - name: Show PR title
+        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true'
         run: |
           echo "The action would generate the following PR title: ${{ steps.title-llm.outputs.response }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
-        if: github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
+        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true' && github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
         with:
           base: main
           commit-message: ${{ steps.title-llm.outputs.response }}

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -22,11 +22,11 @@ jobs:
         id: diff
         run: |
           echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
-          DIFF=$(git diff)
+          DIFF=$(git diff --unified=0)
           echo "${DIFF@Q}" >> $GITHUB_OUTPUT
           echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
 
-          if [ -z "$(git diff)" ]; then
+          if [ -z "$DIFF" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -24,10 +24,6 @@ jobs:
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
           git diff | tee -a $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
-      - name: Check if PR is needed
-        id: pr-needed
-        run: |
-          echo "Diff: ${{ steps.diff.outputs.diff }}"
           if [ -z "${{ steps.diff.outputs.diff }}" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -37,7 +33,7 @@ jobs:
           fi
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
-        if: steps.pr-needed.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:
           model: llama3.2
@@ -53,12 +49,12 @@ jobs:
             The title should be in the present tense.
             The title is:
       - name: Show PR title
-        if: steps.pr-needed.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_changes == 'true'
         run: |
           echo "The action would generate the following PR title: ${{ steps.title-llm.outputs.response }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
-        if: steps.pr-needed.outputs.has_changes == 'true' && github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
+        if: steps.diff.outputs.has_changes == 'true' && github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
         with:
           base: main
           commit-message: ${{ steps.title-llm.outputs.response }}

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -34,6 +34,11 @@ jobs:
       - name: Show diff for debugging
         run: |
           echo "${{ steps.diff.outputs.diff }}"
+      - name: Cache LLM model
+        uses: actions/cache@v4
+        with:
+          path: ~/.ollama
+          key: ${{ runner.os }}-ollama
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
         if: steps.diff.outputs.has_changes == 'true'
@@ -46,10 +51,10 @@ jobs:
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
+            ${{ steps.diff.outputs.diff }}
+
             Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
             Don't include the Python version information in the title or which files are being edited. Focus only on the Kubernetes version.
-
-            ${{ steps.diff.outputs.diff }}
 
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -30,7 +30,11 @@ jobs:
       - name: Check if PR is needed
         id: pr-needed
         run: |
-          echo "has_changes=$([[ ! -z "${{ steps.diff.outputs.diff }}" ]] && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+          if [ -z "${{ steps.diff.outputs.diff }}" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
         if: ${{ steps.pr-needed.outputs.has_changes }} == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -38,19 +38,16 @@ jobs:
         with:
           model: llama3.2
           prompt: |
-            You are a helpful assistant that generates PR titles for Kubernetes version updates.
+            You are a helpful assistant that generates PR titles for Kubernetes version updates by summarising a git diff.
             The title should be concise and to the point, and should not include any markdown formatting.
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
-            Here is a diff of the changes:
+            Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
 
             ```diff
             ${{ steps.diff.outputs.diff }}
             ```
-
-            Use the diff to determine the Kubernetes version that is being updated. 
-            Please generate a PR title with particular attention to the Kubernetes version that is being updated. 
 
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -22,8 +22,10 @@ jobs:
         id: diff
         run: |
           echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
-          git diff | sed 's/["'\'']/\\&/g' | tee -a $GITHUB_OUTPUT
+          DIFF=$(git diff)
+          echo "${DIFF@Q}" >> $GITHUB_OUTPUT
           echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
+
           if [ -z "$(git diff)" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -36,17 +36,12 @@ jobs:
       - name: Show diff for debugging
         run: |
           echo "${{ steps.diff.outputs.diff }}"
-      - name: Cache LLM model
-        uses: actions/cache@v4
-        with:
-          path: ~/.ollama
-          key: ${{ runner.os }}-ollama
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
         if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:
-          model: gemma3:12b
+          model: llama3.2:3b
           prompt: |
             You are a helpful assistant that generates PR titles for Kubernetes version updates by summarising a git diff.
             The title should be concise and to the point, and should not include any markdown formatting.

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -37,7 +37,7 @@ jobs:
           fi
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
-        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true'
+        if: steps.pr-needed.outputs.has_changes == 'true'
         id: title-llm
         with:
           model: llama3.2
@@ -53,12 +53,12 @@ jobs:
             The title should be in the present tense.
             The title is:
       - name: Show PR title
-        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true'
+        if: steps.pr-needed.outputs.has_changes == 'true'
         run: |
           echo "The action would generate the following PR title: ${{ steps.title-llm.outputs.response }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
-        if: ${{ steps.pr-needed.outputs.has_changes }} == 'true' && github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
+        if: steps.pr-needed.outputs.has_changes == 'true' && github.repository == 'kr8s-org/kr8s' && github.ref == 'refs/heads/main'
         with:
           base: main
           commit-message: ${{ steps.title-llm.outputs.response }}

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -22,11 +22,10 @@ jobs:
         id: diff
         run: |
           echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
-          DIFF=$(git diff --unified=0)
-          echo "${DIFF@Q}" >> $GITHUB_OUTPUT
+          git diff | tee -a $GITHUB_OUTPUT
           echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
 
-          if [ -z "$DIFF" ]; then
+          if [ -z "$(git diff)" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
@@ -37,7 +36,7 @@ jobs:
         run: |
           echo "${{ steps.diff.outputs.diff }}"
       - name: Generate PR title
-        uses: ai-action/ollama-action@v1
+        uses: jacobtomlinson/ollama-action@escape-prompt
         if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:
@@ -48,7 +47,9 @@ jobs:
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
+            ```diff
             ${{ steps.diff.outputs.diff }}
+            ```
 
             Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
             Don't include the Python version information in the title or which files are being edited. Focus only on the Kubernetes version.

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -45,7 +45,7 @@ jobs:
 
             Here is a diff of the changes:
 
-            ```
+            ```diff
             ${{ steps.diff.outputs.diff }}
             ```
 

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -21,9 +21,9 @@ jobs:
       - name: Show diff
         id: diff
         run: |
-          echo 'diff<<EOF' >> $GITHUB_OUTPUT
+          echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
           git diff | tee -a $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
           if [ -z "$(git diff)" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -31,6 +31,9 @@ jobs:
             echo "Changes to commit"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+      - name: Show diff for debugging
+        run: |
+          echo "${{ steps.diff.outputs.diff }}"
       - name: Generate PR title
         uses: ai-action/ollama-action@v1
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -47,10 +47,9 @@ jobs:
             Your response must be no more than 50 characters.
 
             Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
+            Don't include the Python version information in the title or which files are being edited. Focus only on the Kubernetes version.
 
-            ```diff
             ${{ steps.diff.outputs.diff }}
-            ```
 
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -14,13 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: pip install ruamel.yaml
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Update Kubernetes
-        run: ./ci/update-kubernetes.py
+        run: uv run ./ci/update-kubernetes.py
       - name: Show diff
         id: diff
         run: |

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -30,9 +30,12 @@ jobs:
       - name: Check if PR is needed
         id: pr-needed
         run: |
+          echo "Diff: ${{ steps.diff.outputs.diff }}"
           if [ -z "${{ steps.diff.outputs.diff }}" ]; then
+            echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
+            echo "Changes to commit"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
       - name: Generate PR title

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -40,16 +40,17 @@ jobs:
           prompt: |
             You are a helpful assistant that generates PR titles for Kubernetes version updates.
             The title should be concise and to the point, and should not include any markdown formatting.
-            The title should be in the format of "Update Kubernetes version: remove 1.27" or similar.
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 
             Here is a diff of the changes:
-            
+
             ```
             ${{ steps.diff.outputs.diff }}
             ```
-            Please generate a PR title with particular attention to the Kubernetes version that is being updated.
+
+            Use the diff to determine the Kubernetes version that is being updated. 
+            Please generate a PR title with particular attention to the Kubernetes version that is being updated. 
 
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -22,10 +22,10 @@ jobs:
         id: diff
         run: |
           echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
-          git diff | tee -a $GITHUB_OUTPUT
+          git diff --unified=0 | tee -a $GITHUB_OUTPUT
           echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
 
-          if [ -z "$(git diff)" ]; then
+          if [ -z "$(git diff --unified=0)" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -24,7 +24,7 @@ jobs:
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
           git diff | tee -a $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
-          if [ -z "${{ steps.diff.outputs.diff }}" ]; then
+          if [ -z "$(git diff)" ]; then
             echo "No changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -38,16 +38,16 @@ jobs:
         with:
           model: llama3.2
           prompt: |
-            Generate a PR title for the following changes:
+            You are a helpful assistant that generates PR titles for Kubernetes version updates.
+            The title should be concise and to the point, and should not include any markdown formatting.
+            The title should be in the format of "Update Kubernetes version: remove 1.27" or similar.
+            The title should be in the present tense.
+            Your response must be no more than 50 characters.
 
+            Please generate a PR title for the following changes:
             ```
             ${{ steps.diff.outputs.diff }}
             ```
-            The title should be concise and to the point, and should not include any markdown formatting.
-            The title should be in the format of "Update Kubernetes version: remove 1.27" or similar.
-            The title should be no more than 50 characters.
-            The title should be in the present tense.
-            The title is:
       - name: Show PR title
         if: steps.diff.outputs.has_changes == 'true'
         run: |

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -36,7 +36,7 @@ jobs:
         if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:
-          model: llama3.2
+          model: gemma3:12b
           prompt: |
             You are a helpful assistant that generates PR titles for Kubernetes version updates by summarising a git diff.
             The title should be concise and to the point, and should not include any markdown formatting.

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -22,7 +22,7 @@ jobs:
         id: diff
         run: |
           echo 'diff<<END_OF_DIFF' >> $GITHUB_OUTPUT
-          git diff | tee -a $GITHUB_OUTPUT
+          git diff | sed 's/["'\'']/\\&/g' | tee -a $GITHUB_OUTPUT
           echo 'END_OF_DIFF' >> $GITHUB_OUTPUT
           if [ -z "$(git diff)" ]; then
             echo "No changes to commit"
@@ -50,6 +50,8 @@ jobs:
             The title should be concise and to the point, and should not include any markdown formatting.
             The title should be in the present tense.
             Your response must be no more than 50 characters.
+
+            ${{ steps.diff.outputs.diff }}
 
             Please summarize the changes in the diff with particular attention to the Kubernetes version that is being updated.
             Don't include the Python version information in the title or which files are being edited. Focus only on the Kubernetes version.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2025, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "ruamel-yaml",
+# ]
+# ///
 
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -7,9 +7,6 @@
 #     "ruamel-yaml",
 # ]
 # ///
-
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025, Kr8s Developers (See LICENSE for list)
-# SPDX-License-Identifier: BSD 3-Clause License
 import json
 import os
 import re


### PR DESCRIPTION
When the Kubernetes version updating action runs it always opens a PR with the title "Update Kubernetes versions".

It would be nice if the title was more descriptive. In this PR I'm playing around with using ollama and an open weights LLM like llama3 to generate the PR title based on the `git diff`.