### PR TITLE
Switch back to `ai-action/ollama-action`

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,8 +29,6 @@ jobs:
             kubernetes-version: 1.32.3
           - python-version: '3.10'
             kubernetes-version: 1.31.6
-          - python-version: '3.10'
-            kubernetes-version: 1.30.10
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "${{ steps.diff.outputs.diff }}"
       - name: Generate PR title
-        uses: jacobtomlinson/ollama-action@escape-prompt
+        uses: ai-action/ollama-action@v1.0.1
         if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:


### PR DESCRIPTION
I originally forked `ai-action/ollama-action` to fix a string escaping issue when working on #610 . They've merged my PR upstream now so this PR switches things back.