### PR TITLE
Update title LLM prompt to discourage using quotes

### DIFF
--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -43,7 +43,7 @@ jobs:
           model: llama3.2:3b
           prompt: |
             You are a helpful assistant that generates PR titles for Kubernetes version updates by summarising a git diff.
-            The title should be concise and to the point, and should not include any markdown formatting.
+            The title should be concise and to the point, and should not include any markdown formatting or quotes.
             The title should be in the present tense.
             Your response must be no more than 50 characters.
 


### PR DESCRIPTION
The LLM title generation keeps including quotes. Tweaking the prompt to discourage this.