### PR TITLE
Feature: create multiple resources

### DIFF
--- a/docs/examples/creating_resources.md
+++ b/docs/examples/creating_resources.md
@@ -279,24 +279,24 @@ Then with `kr8s` we can load this file and create an object for each resource. T
 ````{tab-item} Sync
 :sync: sync
 ```python
+import kr8s
 from kr8s.objects import objects_from_files
 
 resources = objects_from_files("manifest.yaml")
 
-for resource in resources:
-    resource.create()
+kr8s.create(resources)
 ```
 ````
 
 ````{tab-item} Async
 :sync: async
 ```python
+import kr8s.asyncio
 from kr8s.asyncio.objects import objects_from_files
 
 resources = await objects_from_files("manifest.yaml")
 
-for resource in resources:
-    await resource.create()
+await kr8s.asyncio.create(resources)
 ```
 ````
 

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -112,7 +112,7 @@ class Api(_AsyncApi):
         yield from _run_sync(self.async_api_versions)()
 
     def create(self, resources: list[objects.APIObject]):  # type: ignore
-        return _run_sync(self.async_create)(resources) # type: ignore
+        return _run_sync(self.async_create)(resources)  # type: ignore
 
 
 def get(

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -112,8 +112,7 @@ class Api(_AsyncApi):
         yield from _run_sync(self.async_api_versions)()
 
     def create(self, resources: list[objects.APIObject]):  # type: ignore
-        for resource in resources:
-            resource.create()
+        return _run_sync(self.async_create)(resources) # type: ignore
 
 
 def get(

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -111,6 +111,10 @@ class Api(_AsyncApi):
     def api_versions(self) -> Generator[str]:  # type: ignore
         yield from _run_sync(self.async_api_versions)()
 
+    def create(self, resources: list[objects.APIObject]):  # type: ignore
+        for resource in resources:
+            resource.create()
+
 
 def get(
     kind: str,
@@ -218,6 +222,13 @@ def whoami():
     return _run_sync(_whoami)(_asyncio=False)
 
 
+def create(resources: list[type[APIObject]], api=None):
+    """Creates resources in the Kubernetes cluster."""
+    if api is None:
+        api = _run_sync(_api)(_asyncio=False)
+    api.create(resources)  # type: ignore
+
+
 version = _run_sync(partial(_k8s_version, _asyncio=False))
 update_wrapper(version, _k8s_version)
 watch = _run_sync(partial(_watch, _asyncio=False))
@@ -232,6 +243,7 @@ __all__ = [
     "api",
     "api_resources",
     "asyncio",
+    "create",
     "get",
     "objects",
     "portforward",

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -666,7 +666,7 @@ class Api:
     async def async_create(self, resources: list[APIObject]):
         async with asyncio.TaskGroup() as tg:
             for resource in resources:
-                tg.create_task(resource.create())
+                tg.create_task(resource.async_create())
 
     async def create(self, resources: list[APIObject]):
         return await self.async_create(resources)

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 
+import anyio
 import asyncio
 import contextlib
 import copy
@@ -664,9 +665,9 @@ class Api:
                 yield version["groupVersion"]
 
     async def async_create(self, resources: list[APIObject]):
-        async with asyncio.TaskGroup() as tg:
+        async with anyio.create_task_group() as tg:
             for resource in resources:
-                tg.create_task(resource.async_create())
+                tg.start_soon(resource.async_create)
 
     async def create(self, resources: list[APIObject]):
         return await self.async_create(resources)

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -663,6 +663,14 @@ class Api:
             for version in group["versions"]:
                 yield version["groupVersion"]
 
+    async def async_create(self, resources: list[APIObject]):
+        async with asyncio.TaskGroup() as tg:
+            for resource in resources:
+                tg.create_task(resource.create())
+
+    async def create(self, resources: list[APIObject]):
+        return await self.async_create(resources)
+
     @property
     def __version__(self) -> str:
         from . import __version__

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 
-import anyio
 import asyncio
 import contextlib
 import copy
@@ -17,6 +16,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import anyio
 import httpx
 import httpx_ws
 from asyncache import cached  # type: ignore

--- a/kr8s/asyncio/__init__.py
+++ b/kr8s/asyncio/__init__.py
@@ -8,11 +8,12 @@ from kr8s._api import Api
 
 from . import objects, portforward
 from ._api import api
-from ._helpers import api_resources, get, version, watch, whoami
+from ._helpers import api_resources, create, get, version, watch, whoami
 
 __all__ = [
     "api",
     "api_resources",
+    "create",
     "get",
     "objects",
     "portforward",

--- a/kr8s/asyncio/_helpers.py
+++ b/kr8s/asyncio/_helpers.py
@@ -107,6 +107,14 @@ async def whoami(api=None, _asyncio=True):
     return await api.async_whoami()
 
 
+async def create(resources: list[APIObject], api=None, _asyncio=True):
+    """Create resources in the Kubernetes cluster."""
+    if api is None:
+        api = await _api(_asyncio=_asyncio)
+    return await api.async_create(resources)
+
+
+create.__doc__ = Api.create.__doc__
 get.__doc__ = Api.get.__doc__
 version.__doc__ = Api.version.__doc__
 watch.__doc__ = Api.watch.__doc__


### PR DESCRIPTION
Added new convenient methods to create multiple resources in a single call (See discussion on issue #526).

Examples:

Sync version:

```python
import kr8s
from kr8s.objects import objects_from_files

resources = objects_from_files("manifest.yaml")

kr8s.create(resources)
```

Async version:

```python
import kr8s.asyncio
from kr8s.asyncio.objects import objects_from_files

resources = await objects_from_files("manifest.yaml")

await kr8s.asyncio.create(resources)
```

Closes #526 