### PR TITLE
Remove PR title generation workaround

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,6 +29,8 @@ jobs:
             kubernetes-version: 1.32.5
           - python-version: '3.10'
             kubernetes-version: 1.31.9
+          - python-version: '3.10'
+            kubernetes-version: 1.30.13
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,8 +29,6 @@ jobs:
             kubernetes-version: 1.32.5
           - python-version: '3.10'
             kubernetes-version: 1.31.9
-          - python-version: '3.10'
-            kubernetes-version: 1.30.13
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/update-kubernetes.yaml
+++ b/.github/workflows/update-kubernetes.yaml
@@ -36,12 +36,11 @@ jobs:
         run: |
           echo "${{ steps.diff.outputs.diff }}"
       - name: Generate PR title
-        uses: ai-action/ollama-action@v1.0.1
+        uses: ai-action/ollama-action@v1.1.1
         if: steps.diff.outputs.has_changes == 'true'
         id: title-llm
         with:
           model: llama3.2:3b
-          version: 0.9.5
           prompt: |
             You are a helpful assistant that generates PR titles for Kubernetes version updates by summarising a git diff.
             The title should be concise and to the point, and should not include any markdown formatting or quotes.


### PR DESCRIPTION
Remove the workaround added in #636. 
Upgrading to 1.1.1 was suggested in https://github.com/ai-action/ollama-action/issues/8#issuecomment-3036728816