### PR TITLE
Fix deleting and recreating resources

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -135,6 +135,18 @@ class APIObject:
         self._raw = Box(value)
 
     @property
+    def raw_template(self) -> Box:
+        """Template representation of the Kubernetes resource without instance-specific data.
+
+        Returns a copy of the raw object with metadata.resourceVersion and status removed.
+        This is useful for creating new resources based on existing ones.
+        """
+        template = self.raw.copy()
+        if "metadata" in template:
+            template.metadata.pop("resourceVersion", None)
+        return template
+
+    @property
     def name(self) -> str:
         """Name of the Kubernetes resource."""
         if "name" in self.metadata:
@@ -353,7 +365,7 @@ class APIObject:
             version=self.version,
             url=self.endpoint,
             namespace=self.namespace,
-            data=json.dumps(self.raw),
+            data=json.dumps(self.raw_template),
         ) as resp:
             self.raw = resp.json()
 

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1416,3 +1416,12 @@ async def test_recreate_pod(ns):
         await anyio.sleep(0.1)
     assert await po.exists()
     await po.delete()
+
+
+async def test_create_existing_pod_fails():
+    po = await kr8s.asyncio.objects.Pod.gen(
+        generate_name="nginx-", image="nginx:latest"
+    )
+    await po.create()
+    with pytest.raises(kr8s.ServerError, match="already exists"):
+        await po.create()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1409,6 +1409,10 @@ async def test_recreate_pod(ns):
     )
     await po.create()
     await po.delete()
+    while await po.exists():
+        await anyio.sleep(0.1)
     await po.create()
+    while not await po.exists():
+        await anyio.sleep(0.1)
     assert await po.exists()
     await po.delete()

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1401,3 +1401,14 @@ async def test_generate_name():
         assert po.metadata.generateName in po.name
     finally:
         await po.delete()
+
+
+async def test_recreate_pod(ns):
+    po = await kr8s.asyncio.objects.Pod.gen(
+        generate_name="nginx-", image="nginx:latest", namespace=ns
+    )
+    await po.create()
+    await po.delete()
+    await po.create()
+    assert await po.exists()
+    await po.delete()


### PR DESCRIPTION
If you delete a resource and then try to recreate it you will get a 500 error from the Kubernetes API. This does not match the same experience in `kubectl`. 

Closes #640 