### PR TITLE
Use content arg instead of data when calling api

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -290,7 +290,7 @@ class Api:
                 "POST",
                 version="authentication.k8s.io/v1",
                 url="tokenreviews",
-                data=json.dumps(payload),
+                content=json.dumps(payload),
             ) as r:
                 data = r.json()
                 return data["status"]["user"]["username"]

--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -365,7 +365,7 @@ class APIObject:
             version=self.version,
             url=self.endpoint,
             namespace=self.namespace,
-            data=json.dumps(self.raw_template),
+            content=json.dumps(self.raw_template),
         ) as resp:
             self.raw = resp.json()
 
@@ -415,7 +415,7 @@ class APIObject:
                 version=self.version,
                 url=f"{self.endpoint}/{self.name}",
                 namespace=self.namespace,
-                data=json.dumps(data),
+                content=json.dumps(data),
             ):
                 pass
         except ServerError as e:
@@ -469,7 +469,7 @@ class APIObject:
                 version=self.version,
                 url=url,
                 namespace=self.namespace,
-                data=json.dumps(patch),
+                content=json.dumps(patch),
                 headers=headers,
             ) as resp:
                 self.raw = resp.json()


### PR DESCRIPTION
`httpx` has a `DeprecationWarning` when passing raw request content in the `data` argument instead of `content`.
See: https://www.python-httpx.org/compatibility/#request-content