### PR TITLE
fix: empty singular name for k8s resources

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -326,15 +326,15 @@ class Api:
             version = f"{group}/{version}"
         for resource in resources:
             name = resource["name"]
-            singular_name = resource['singularName']
+            singular_name = resource["singularName"]
             if len(singular_name) == 0:
                 singular_name = name.lower()
 
             if (not version or version in resource["version"]) and (
-                    kind == name
-                    or kind == resource["kind"]
-                    or kind == singular_name
-                    or ("shortNames" in resource and kind in resource["shortNames"])
+                kind == name
+                or kind == resource["kind"]
+                or kind == singular_name
+                or ("shortNames" in resource and kind in resource["shortNames"])
             ):
                 if "/" in resource["version"]:
                     return (


### PR DESCRIPTION
The issue with singular name is that during the `async_pods` execution it may not find the class of the resource if the resources' `singularName` is empty.

My problematic resource definition in the cluster:
```
{
    "version": "v1",
    "name": "pods",
    "singularName": "",
    "namespaced": true,
    "kind": "Pod",
    "verbs": [
      "create",
      "delete",
      "deletecollection",
      "get",
      "list",
      "patch",
      "update",
      "watch"
    ],
    "shortNames": [
      "po"
    ],
    "categories": [
      "all"
    ]
  },
```