### PR TITLE
Fix Kubernetes support dropping versions too early

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -29,6 +29,8 @@ jobs:
             kubernetes-version: 1.32.5
           - python-version: '3.10'
             kubernetes-version: 1.31.9
+          - python-version: '3.10'
+            kubernetes-version: 1.30.13
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/test-kubectl-ng.yaml
+++ b/.github/workflows/test-kubectl-ng.yaml
@@ -27,6 +27,8 @@ jobs:
             kubernetes-version: 1.32.5
           - python-version: '3.10'
             kubernetes-version: 1.31.9
+          - python-version: '3.10'
+            kubernetes-version: 1.30.13
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -51,10 +51,9 @@ def get_kubernetes_oss_versions():
             {
                 "cycle": x["cycle"],
                 "latest_version": x["latest"],
-                "eol": datetime.strptime(x["eol"], DATE_FORMAT),
+                "eol": get_support_date(x),
             }
             for x in data
-            if datetime.strptime(x["eol"], DATE_FORMAT) > datetime.now()
         ]
         data.sort(key=lambda x: x["eol"], reverse=True)
     return data
@@ -72,7 +71,6 @@ def get_azure_aks_versions():
                 "eol": get_support_date(x),
             }
             for x in data
-            if get_support_date(x) > datetime.now()
         ]
         data.sort(key=lambda x: x["eol"], reverse=True)
     return data
@@ -89,7 +87,6 @@ def get_amazon_eks_versions():
                 "eol": get_support_date(x),
             }
             for x in data
-            if get_support_date(x) > datetime.now()
         ]
         data.sort(key=lambda x: x["eol"], reverse=True)
     return data
@@ -106,7 +103,6 @@ def get_google_kubernetes_engine_versions():
                 "eol": get_support_date(x),
             }
             for x in data
-            if get_support_date(x) > datetime.now()
         ]
         data.sort(key=lambda x: x["eol"], reverse=True)
     return data
@@ -142,12 +138,15 @@ def get_kind_versions():
 
 
 def get_versions():
-    oss_versions = get_kubernetes_oss_versions()
-    versions = extend_versions(oss_versions, get_azure_aks_versions(), "Azure AKS")
+    versions = get_kubernetes_oss_versions()
+    versions = extend_versions(versions, get_azure_aks_versions(), "Azure AKS")
     versions = extend_versions(versions, get_amazon_eks_versions(), "Amazon EKS")
     versions = extend_versions(
         versions, get_google_kubernetes_engine_versions(), "Google Kubernetes Engine"
     )
+    print("Pruning versions that are past their support date...")
+    versions = [x for x in versions if x["eol"] > datetime.now()]
+
     container_tags = get_kind_versions()
 
     for version in versions:

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 <iframe src="https://ghbtns.com/github-btn.html?user=kr8s-org&repo=kr8s&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>


### PR DESCRIPTION
I wanted to play around with the support window to see how many extra versions would be added to our CI matrix if we match the extended support windows of the cloud vendors.

I updated the support window script to allow configuration of minimal or maximal support windows.

While doing this I discovered a bug which was causing us to drop versions too early. If a version was dropped by OSS it couldn't be extended by other support versions.

So this PR adds the ability to configure `standard` or `extended` support. It then sets it to `standard` for now. However with the bug fixed it does reverse #637 and reinstate 1.30 because GKE supports it until September 2025.