### PR TITLE
Switch CI to extended support

### DIFF
--- a/.github/workflows/test-kr8s.yaml
+++ b/.github/workflows/test-kr8s.yaml
@@ -31,6 +31,10 @@ jobs:
             kubernetes-version: 1.31.9
           - python-version: '3.10'
             kubernetes-version: 1.30.13
+          - python-version: '3.10'
+            kubernetes-version: 1.29.14
+          - python-version: '3.10'
+            kubernetes-version: 1.28.15
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/.github/workflows/test-kubectl-ng.yaml
+++ b/.github/workflows/test-kubectl-ng.yaml
@@ -29,6 +29,10 @@ jobs:
             kubernetes-version: 1.31.9
           - python-version: '3.10'
             kubernetes-version: 1.30.13
+          - python-version: '3.10'
+            kubernetes-version: 1.29.14
+          - python-version: '3.10'
+            kubernetes-version: 1.28.15
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12%7C3.13-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.28%7C1.29%7C1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 

--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -22,7 +22,7 @@ yaml.preserve_quotes = True
 yaml.indent(mapping=2, sequence=4, offset=2)
 
 DATE_FORMAT = "%Y-%m-%d"
-SUPPORT_MODE = "standard"  # "standard" or "extended"
+SUPPORT_MODE = "extended"  # "standard" or "extended"
 
 
 def extract_dates(data):

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 [![PyPI](https://img.shields.io/pypi/v/kr8s)](https://pypi.org/project/kr8s/)
 [![Python Version Support](https://img.shields.io/badge/Python%20support-3.9%7C3.10%7C3.11%7C3.12%7C3.13-blue)](https://pypi.org/project/kr8s/)
-[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
+[![Kubernetes Version Support](https://img.shields.io/badge/Kubernetes%20support-1.28%7C1.29%7C1.30%7C1.31%7C1.32%7C1.33-blue)](https://docs.kr8s.org/en/stable/installation.html#supported-kubernetes-versions)
 [![PyPI - Wheel](https://img.shields.io/pypi/wheel/kr8s)](https://pypi.org/project/kr8s/)
 [![PyPI - License](https://img.shields.io/pypi/l/kr8s)](https://pypi.org/project/kr8s/)
 <iframe src="https://ghbtns.com/github-btn.html?user=kr8s-org&repo=kr8s&type=star&count=true" frameborder="0" scrolling="0" width="150" height="20" title="GitHub"></iframe>


### PR DESCRIPTION
Updates `kr8s` Kubernetes version support to follow cloud vendor extended support windows. Many cloud vendors provide an extra 12 months of support for a Kubernetes version beyond what the open source community provides.

I'm not necessarily committing to doing this, we are part of the open source community and typically follow their lead. But I'm just curious what the impact on CI workflows is and whether anything is actually broken in older versions.