### PR TITLE
Raise a warning if kr8s is used on an unsupported Kubernetes version

### DIFF
--- a/ci/update-kubernetes.py
+++ b/ci/update-kubernetes.py
@@ -220,6 +220,21 @@ def update_badges(filename, versions):
     Path(filename).write_text(readme)
 
 
+def update_version_support(versions):
+    version_support = Path("kr8s/_constants.py").read_text()
+    version_support = re.sub(
+        r"KUBERNETES_MINIMUM_SUPPORTED_VERSION = .*",
+        f"KUBERNETES_MINIMUM_SUPPORTED_VERSION = parse_version(\"{versions[-1]['cycle']}\")",
+        version_support,
+    )
+    version_support = re.sub(
+        r"KUBERNETES_MAXIMUM_SUPPORTED_VERSION = .*",
+        f"KUBERNETES_MAXIMUM_SUPPORTED_VERSION = parse_version(\"{versions[0]['cycle']}\")",
+        version_support,
+    )
+    Path("kr8s/__init__.py").write_text(version_support)
+
+
 def main():
     versions = get_versions()
     print(f"Latest version: {versions[0]['cycle']}")
@@ -235,6 +250,7 @@ def main():
         update_workflow(versions, ".github/workflows/test-kubectl-ng.yaml")
         update_badges("README.md", versions)
         update_badges("docs/index.md", versions)
+        update_version_support(versions)
     else:
         print("DEBUG env var set, skipping file updates")
 

--- a/kr8s/__init__.py
+++ b/kr8s/__init__.py
@@ -19,6 +19,10 @@ from ._api import ALL
 from ._api import Api as _AsyncApi
 from ._async_utils import as_sync_func as _as_sync_func
 from ._async_utils import as_sync_generator as _as_sync_generator
+from ._constants import (
+    KUBERNETES_MAXIMUM_SUPPORTED_VERSION,
+    KUBERNETES_MINIMUM_SUPPORTED_VERSION,
+)
 from ._exceptions import (
     APITimeoutError,
     ConnectionClosedError,
@@ -265,4 +269,6 @@ __all__ = [
     "ExecError",
     "NotFoundError",
     "ServerError",
+    "KUBERNETES_MINIMUM_SUPPORTED_VERSION",
+    "KUBERNETES_MAXIMUM_SUPPORTED_VERSION",
 ]

--- a/kr8s/_constants.py
+++ b/kr8s/_constants.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from packaging.version import parse as parse_version
+
+KUBERNETES_MINIMUM_SUPPORTED_VERSION = parse_version("1.28")
+KUBERNETES_MAXIMUM_SUPPORTED_VERSION = parse_version("1.33")

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 import queue
 import threading
+from unittest.mock import AsyncMock
 
 import anyio
 import pytest
@@ -487,3 +488,12 @@ def test_create_sync(example_pod_spec, example_service_spec):
     assert service.exists(), "Service should exist after creation"
     pod.delete()
     service.delete()
+
+
+async def test_bad_kubernetes_version():
+    api = await kr8s.asyncio.api()
+    keep = api.async_version
+    api.async_version = AsyncMock(return_value={"gitVersion": "1.27.0"})
+    with pytest.warns(UserWarning):
+        await api._check_version()
+    api.async_version = keep


### PR DESCRIPTION
Closes #594.

If you use `kr8s` with an unsupported Kubernetes version it will warn. It doesn't mean it won't work, but at least we are telling folks.

The supported value range is set via a constant which is updated by the same script that keeps CI up to date. That way we can be confident that the users version has been explicitly tested, and warn if not.