### PR TITLE
Update conventional commit bug label

### DIFF
--- a/.github/conventional-commits-labeler.yml
+++ b/.github/conventional-commits-labeler.yml
@@ -1,5 +1,5 @@
 skip-changelog: ['pre-commit-ci-*']
-bug: 'fix/*'
+bug: ['fix/*', 'bug/*']
 enhancement: ['feature/*', 'feat/*']
 documentation: ['docs/*', 'doc/*']
 hygiene: ['ci/*', 'test/*', 'build/*', 'chore/*']


### PR DESCRIPTION
I noticed in #669 that the conventional commit labeller (added in #666) added the label `fix` instead of `bug`. I _think_ this should fix it.