### PR TITLE
Configure Dependabot for UV package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adding dependabot to keep `uv.lock` in sync. 

UV docs https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependabot