### PR TITLE
Make version checking more flexible

### DIFF
--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -273,18 +273,17 @@ class Api:
     async def _check_version(self) -> None:
         version = await self.async_version()
         git_version = version["gitVersion"]
-        # Remove variant suffix if present, e.g v1.32.9-eks-113cf36 -> v1.32.9
-        git_version = git_version.split("-")[0] if "-" in git_version else git_version
 
         supported_message = (
-            "Supported versions for kr8s {__version__} are "
+            f"Supported versions for kr8s {__version__} are "
             f"{KUBERNETES_MINIMUM_SUPPORTED_VERSION}"
             " to "
             f"{KUBERNETES_MAXIMUM_SUPPORTED_VERSION}."
         )
 
         try:
-            version = parse_version(git_version)
+            # Remove variant suffix if present before parsing, e.g v1.32.9-eks-113cf36 -> v1.32.9
+            version = parse_version(git_version.split("-")[0])
         except InvalidVersion:
             warnings.warn(
                 f"Unable to parse Kubernetes version {git_version}. {supported_message}",

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -527,7 +527,7 @@ async def test_bad_kubernetes_version(version):
     api = await kr8s.asyncio.api()
     keep = api.async_version
     api.async_version = AsyncMock(return_value={"gitVersion": version})
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning, match=version):
         await api._check_version()
     api.async_version = keep
 


### PR DESCRIPTION
- Catch version parsing error and raise a more generic warning (avoid breaks like #685 for versions we haven't thought of)
- Update version parsing to handle EKS version strings like `"v1.27.0-eks-113cf36"`
- Update tests to try a range of invalid versions

Closes #685 
Follow on to #668 