### PR TITLE
Only require typing_extensions on python<3.12

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import pathlib
 import re
+import sys
 import time
 from collections.abc import AsyncGenerator, Generator
 from typing import (
@@ -20,7 +21,11 @@ import httpx
 import jsonpath
 import yaml
 from box import Box
-from typing_extensions import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 import kr8s
 import kr8s.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx>=0.24.1",
     "httpx-ws>=0.7.0",
     "python-box>=7.0.1",
-    "typing_extensions>=4.12.2",
+    "typing_extensions>=4.12.2; python_version < '3.12'",
     "cachetools>=5.2.0",
 ]
 


### PR DESCRIPTION
- Ensure all `typing_extensions` usage is behind Python version checks, prefer importing from `typing` if possible.
- Update dependencies to only install `typing_extensions` on Python versions where we use it.