### PR TITLE
Fix missing properties key in tests

### DIFF
--- a/kr8s/_config.py
+++ b/kr8s/_config.py
@@ -334,7 +334,7 @@ class KubeConfig(KubeConfigMixin):
 
     @property
     def preferences(self) -> list[dict]:
-        return self._raw.get("preferences", {})
+        return self._raw.get("preferences", [])
 
     @property
     def clusters(self) -> list[dict]:


### PR DESCRIPTION
Relates to #692 #691 

I didn't run any tests locally. I'm NixOS and haven't figured out all the bells and whistles of Python yet