### PR TITLE
Make sniffio optional

### DIFF
--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Literal, Union
 
 import anyio
 import httpx_ws
-import sniffio
 
 from ._exceptions import ConnectionClosedError
 from ._types import APIObjectWithPods
@@ -86,12 +85,15 @@ class PortForward:
         local_port: LocalPortType = "match",
         address: list[str] | str = "127.0.0.1",
     ) -> None:
-        with suppress(sniffio.AsyncLibraryNotFoundError):
-            if sniffio.current_async_library() != "asyncio":
-                raise RuntimeError(
-                    "PortForward only works with asyncio, "
-                    "see https://github.com/kr8s-org/kr8s/issues/104"
-                )
+        with suppress(ImportError):
+            import sniffio
+
+            with suppress(sniffio.AsyncLibraryNotFoundError):
+                if sniffio.current_async_library() != "asyncio":
+                    raise RuntimeError(
+                        "PortForward only works with asyncio, "
+                        "see https://github.com/kr8s-org/kr8s/issues/104"
+                    )
         self.server = None
         self.servers: list[asyncio.Server] = []
         self.remote_port = remote_port


### PR DESCRIPTION
Closes #708 

It looks like `anyio>=4.12.0` has made `sniffio` an optional dependency. It only installs it if you're using the `trio` backend.

We also use `sniffio` in `kr8s` to detect if you're using the `trio` backend, and we only do it to raise an exception in features that aren't supported in `trio` (see #77).

Given that `sniffio` will only be installed if the `trio` backend for `anyio` is installed I don't think we need to add `sniffio` as a hard dependency here. We can do the same as `anyio` and make it an optional import.