### PR TITLE
Use a multi-arch pause image for pytests

### DIFF
--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -20,8 +20,13 @@ HERE = Path(__file__).parent.resolve()
 DEFAULT_LABELS = {"created-by": "kr8s-tests"}
 
 
+@pytest.fixture(scope="session")
+def pause_image():
+    return "registry.k8s.io/pause:3.9"
+
+
 @pytest.fixture
-async def example_pod_spec(ns):
+async def example_pod_spec(ns, pause_image):
     name = "example-" + uuid.uuid4().hex[:10]
     return {
         "apiVersion": "v1",
@@ -32,14 +37,12 @@ async def example_pod_spec(ns):
             "labels": {"hello": "world", **DEFAULT_LABELS},
             "annotations": {"foo": "bar"},
         },
-        "spec": {
-            "containers": [{"name": "pause", "image": "gcr.io/google_containers/pause"}]
-        },
+        "spec": {"containers": [{"name": "pause", "image": pause_image}]},
     }
 
 
 @pytest.fixture
-async def bad_pod_spec(ns):
+async def bad_pod_spec(ns, pause_image):
     name = "example-" + uuid.uuid4().hex[:10]
     return {
         "apiVersion": "v1",
@@ -52,7 +55,7 @@ async def bad_pod_spec(ns):
             "containers": [
                 {
                     "name1": "pause",  # This is bad
-                    "image": "gcr.io/google_containers/pause",
+                    "image": pause_image,
                 }
             ]
         },
@@ -79,7 +82,7 @@ async def example_service_spec(ns):
 
 
 @pytest.fixture
-async def example_deployment_spec(ns):
+async def example_deployment_spec(ns, pause_image):
     name = "example-" + uuid.uuid4().hex[:10]
     return {
         "apiVersion": "apps/v1",
@@ -99,7 +102,7 @@ async def example_deployment_spec(ns):
                     "containers": [
                         {
                             "name": "pause",
-                            "image": "gcr.io/google_containers/pause",
+                            "image": pause_image,
                         }
                     ]
                 },

--- a/kr8s/tests/test_api.py
+++ b/kr8s/tests/test_api.py
@@ -465,10 +465,10 @@ async def test_get_dynamic_plurals(kind, ensure_gc):
     assert isinstance([resource async for resource in api.get(kind)], list)
 
 
-async def test_two_pods(ns):
+async def test_two_pods(ns, pause_image):
     gen_kwargs = {
         "generate_name": "example-",
-        "image": "gcr.io/google_containers/pause",
+        "image": pause_image,
         "namespace": ns,
     }
     pods = [await Pod.gen(**gen_kwargs), await Pod.gen(**gen_kwargs)]


### PR DESCRIPTION
This enables running pytests on my MacBook running on an Apple M3 Max chip. The issue was the pause image used in the tests is not a multi-architecture image, and is unable to run on an arm style chip. This changes the pause image used from `gcr.io/google_containers/pause` to instead use `registry.k8s.io/pause:3.9`. With this change is place, all tests pass!

Awesome kubernetes client btw! I am working towards getting my Popen style exec working on it.