### PR TITLE
Implement pod exec using a Popen like object

### DIFF
--- a/examples/exec_popen.py
+++ b/examples/exec_popen.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+"""
+Examples of using resource.popen, which exposes the pod exec call using a subprocess.Popen
+like object, with support for both binary and text data.
+
+
+kr8s.objects.APIObject.popen method:
+
+  command    - The remote command to executem, not executed within a shell.
+  container  - Optional container to execute the command in.
+  tty        - Enable tty mode for the exec call.
+  buffer     - Enable buffering stdout and stderr
+  text       - Enable text mode, stdin, stdout, and stderr will be strings, rather than bytes.
+  encoding   - Text encoding format if text mode.
+  errors     - Text encoding error strictness if text mode.
+  stdin      - Redirect the standard input stream of the pod for this call.
+  stdout     - Redirect the standard output stream of the pod for this call.
+  stderr     - Redirect the standard error stream of the pod for this call.
+  stderr2out - Redirect the standard error stream of the pod to stdout for this call.
+  timeout    - Timeout in seconds.
+
+kr8s._exec.AsyncPopen fields:
+
+  resource   - APIObject popen called on
+  pod        - Pod used to run exec on
+  container  - Pod container use to run exec on
+  command    - Exec command run
+  tty        - tty enabled
+  buffer     - buffering stdout and stdin enabled
+  text       - if text mode enabled for stdin, stdout, and stderr
+  encodning  - text mode encoding
+  errors     - text mode errors strictness
+  stdin      - if enabled, an anyio.ByteSendStream
+  stdout     - if enabled, an anyio.ByteReceiveStream
+  stderr     - if enabled, an anyio.ByteReceiveStream
+  result     - full result object returned by kubernetes
+  returncode - exec process return code when complete
+  closed     - flag if the exec connecition is closed
+  timeout    - timeout setting
+
+kubernetes.stream.Popen Methods
+
+  resize      - resize the tty width and height
+  communicate - same as subprocess.Popen.communicate
+  wait        - same as subprocess.Popen.wait
+  close       - close the kubernetes connection
+
+"""
+
+import os
+import select
+import sys
+import termios
+import time
+import tty
+
+import anyio
+
+import kr8s
+
+
+##############################################################################
+# Provision the test pod
+async def provision_pod(api):
+    pod = await kr8s.asyncio.objects.Pod("busybox-example", "default", api)
+    if await pod.exists():
+        await pod.refresh()
+    else:
+        print(f"Pod {pod.name} does not exist. Creating it...")
+        pod.spec = {
+            "containers": [
+                {
+                    "image": "busybox",
+                    "name": "sleep",
+                    "tty": True,
+                    "args": [
+                        "/bin/cat",
+                    ],
+                }
+            ]
+        }
+        await pod.create()
+        while not await pod.ready():
+            await anyio.sleep(1)
+        print("Done.")
+    return pod
+
+
+##################################################################
+# Calling exec and waiting for response
+async def simple_response(pod):
+    command = [
+        "/bin/sh",
+        "-c",
+        "echo This message goes to stdout;echo This message goes to stderr >&2",
+    ]
+
+    ex = await pod.exec(command)
+    print(f"STDOUT: {ex.stdout.decode()}", end="", flush=True)
+    print(f"STDERR: {ex.stderr.decode()}", end="", flush=True)
+
+    async with pod.popen(*command, text=True, stdout=True, stderr=True) as popen:
+        stdout, stderr = await popen.communicate()
+    print(f"STDOUT: {stdout}", end="", flush=True)
+    print(f"STDERR: {stderr}", end="", flush=True)
+
+
+##################################################################
+# stdin handling
+async def stdin_sent(pod):
+    async with pod.popen(
+        "sh",
+        "-c",
+        'printf ">>>";cat;printf "<<<"',
+        text=True,
+        stdin=True,
+        stdout=True,
+        stderr=True,
+    ) as popen:
+        stdout, stderr = await popen.communicate("test")
+    print(f"STDOUT: {stdout}", flush=True)
+    if stderr:
+        print(f"STDERR: {stderr}", flush=True)
+
+
+##################################################################
+# Calling a process interactively
+async def interactive(pod):
+    async with pod.popen(
+        "/bin/sh", text=True, stdin=True, stdout=True, stderr=True
+    ) as popen:
+        commands = [
+            "echo This message goes to stdout",
+            "echo This message goes to stderr >&2",
+        ]
+        # Do non-blocking stdout and stderr reads.
+        popen.timeout = 0
+        while commands and not popen.closed:
+            line = commands.pop(0)
+            print("Running command... %s" % line, flush=True)
+            await popen.stdin.send(line + "\n")
+            time.sleep(1)
+            try:
+                line = await popen.stdout.receive()
+                print("STDOUT: %s" % line, end="", flush=True)
+            except TimeoutError:
+                pass
+            try:
+                line = await popen.stderr.receive()
+                print("STERR: %s" % line, end="", flush=True)
+            except TimeoutError:
+                pass
+        popen.timeout = 3
+        await popen.stdin.send("date\n")
+        line = await popen.stdout.receive()
+        print("Server date command returns: %s" % line, end="", flush=True)
+        popen.timeout = 3
+        await popen.stdin.send("whoami\n")
+        line = await popen.stdout.receive()
+        print("Server user is: %s" % line, end="", flush=True)
+
+
+##################################################################
+# Full TTY integration running top, uses local posix apis and raw i/o.
+#
+# There is probably a better way to handle stdin and resize using anyio.
+
+
+async def top(pod):
+
+    async def stdin_handler(popen, stdin):
+        while not popen.closed:
+            # Check if there is anything from our stdin
+            r, _, _ = select.select([stdin], [], [], 0)
+            if r:
+                # Read from our stdin
+                data = os.read(stdin, 1024)
+                # Write it to remote top's stdin
+                await popen.stdin.send(data)
+            await anyio.sleep(0)
+
+    async def stdout_handler(popen):
+        stdout = sys.stdout.fileno()
+        async for data in popen.stdout:
+            os.write(stdout, data)
+
+    async def resize_handler(popen):
+        size = None
+        while not popen.closed:
+            resize = os.get_terminal_size()
+            if not size or resize.columns != size.columns or resize.lines != size.lines:
+                # Inform remote top of the size of the terminal.
+                await popen.resize(resize.columns, resize.lines)
+                size = resize
+            await anyio.sleep(0)
+
+    async with pod.popen("/bin/top", tty=True, stdin=True, stdout=True) as popen:
+        # Enable raw tty mode with no echoing or buffering
+        stdin = sys.stdin.fileno()
+        tcattr = termios.tcgetattr(stdin)
+        tty.setraw(stdin)
+        try:
+            async with anyio.create_task_group() as group:
+                group.start_soon(stdin_handler, popen, stdin)
+                group.start_soon(stdout_handler, popen)
+                group.start_soon(resize_handler, popen)
+            await popen.wait()
+        finally:
+            # Restore the original tty attributes from raw mode
+            termios.tcsetattr(stdin, termios.TCSANOW, tcattr)
+
+
+async def main():
+    pod = await provision_pod(await kr8s.asyncio.api())
+    await simple_response(pod)
+    await stdin_sent(pod)
+    await interactive(pod)
+    await top(pod)
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/examples/exec_popen_sync.py
+++ b/examples/exec_popen_sync.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+"""
+Examples of using resource.popen, which exposes the pod exec call using a subprocess.Popen
+like object, with support for both binary and text data.
+
+
+kr8s.objects.APIObject.popen method:
+
+  command    - The remote command to executem, not executed within a shell.
+  container  - Optional container to execute the command in.
+  tty        - Enable tty mode for the exec call.
+  buffer     - Enable buffering stdout and stderr
+  text       - Enable text mode, stdin, stdout, and stderr will be strings, rather than bytes.
+  encoding   - Text encoding format if text mode.
+  errors     - Text encoding error strictness if text mode.
+  stdin      - Redirect the standard input stream of the pod for this call.
+  stdout     - Redirect the standard output stream of the pod for this call.
+  stderr     - Redirect the standard error stream of the pod for this call.
+  stderr2out - Redirect the standard error stream of the pod to stdout for this call.
+  timeout    - Timeout in seconds.
+
+kr8s._exec.AsyncPopen fields:
+
+  resource   - APIObject popen called on
+  pod        - Pod used to run exec on
+  container  - Pod container use to run exec on
+  command    - Exec command run
+  tty        - tty enabled
+  buffer     - buffering stdout and stdin enabled
+  text       - if text mode enabled for stdin, stdout, and stderr
+  encodning  - text mode encoding
+  errors     - text mode errors strictness
+  stdin      - if enabled, an io.RawIOBase
+  stdout     - if enabled, an io.RawIOBase
+  stderr     - if enabled, an io.RawIOBase
+  result     - full result object returned by kubernetes
+  returncode - exec process return code when complete
+  closed     - flag if the exec connecition is closed
+  timeout    - timeout setting
+
+kubernetes.stream.Popen Methods
+
+  resize      - resize the tty width and height
+  communicate - same as subprocess.Popen.communicate
+  wait        - same as subprocess.Popen.wait
+  close       - close the kubernetes connection
+
+"""
+
+import os
+import select
+import sys
+import tarfile
+import termios
+import time
+import tty
+
+import kr8s
+
+
+##############################################################################
+# Provision the test pod
+def provision_pod(api):
+    pod = kr8s.objects.Pod("busybox-example", "default", api)
+    if pod.exists():
+        pod.refresh()
+    else:
+        print(f"Pod {pod.name} does not exist. Creating it...")
+        pod.spec = {
+            "containers": [
+                {
+                    "image": "busybox",
+                    "name": "sleep",
+                    "tty": True,
+                    "args": [
+                        "/bin/cat",
+                    ],
+                }
+            ]
+        }
+        pod.create()
+        while not pod.ready():
+            time.sleep(1)
+            print("Done.")
+    return pod
+
+
+##################################################################
+# Calling exec and waiting for response
+def simple_response(pod):
+    command = [
+        "/bin/sh",
+        "-c",
+        "echo This message goes to stdout;echo This message goes to stderr >&2",
+    ]
+
+    ex = pod.exec(command)
+    print(f"STDOUT: {ex.stdout.decode()}", end="", flush=True)
+    print(f"STDERR: {ex.stderr.decode()}", end="", flush=True)
+
+    with pod.popen(*command, text=True, stdout=True, stderr=True) as popen:
+        stdout, stderr = popen.communicate()
+        print(f"STDOUT: {stdout}", end="", flush=True)
+        print(f"STDERR: {stderr}", end="", flush=True)
+
+
+##################################################################
+# stdin handling
+def stdin_sent(pod):
+    with pod.popen(
+        "sh",
+        "-c",
+        'printf ">>>";cat;printf "<<<"',
+        text=True,
+        stdin=True,
+        stdout=True,
+        stderr=True,
+    ) as popen:
+        stdout, stderr = popen.communicate("test")
+        print(f"STDOUT: {stdout}", flush=True)
+    if stderr:
+        print(f"STDERR: {stderr}", flush=True)
+
+
+##################################################################
+# Calling a process interactively
+def interactive(pod):
+    with pod.popen("/bin/sh", text=True, stdin=True, stdout=True, stderr=True) as popen:
+        commands = [
+            "echo This message goes to stdout",
+            "echo This message goes to stderr >&2",
+        ]
+        # Do non-blocking stdout and stderr reads.
+        popen.timeout = 0
+        while commands and not popen.closed:
+            line = commands.pop(0)
+            print("Running command... %s" % line, flush=True)
+            popen.stdin.write(line + "\n")
+            time.sleep(1)
+            try:
+                line = popen.stdout.readline()
+                print("STDOUT: %s" % line, end="", flush=True)
+            except TimeoutError:
+                pass
+            try:
+                line = popen.stderr.readline()
+                print("STERR: %s" % line, end="", flush=True)
+            except TimeoutError:
+                pass
+            popen.timeout = 3
+            popen.stdin.write("date\n")
+            line = popen.stdout.readline()
+            print("Server date command returns: %s" % line, end="", flush=True)
+            popen.timeout = 3
+            popen.stdin.write("whoami\n")
+            line = popen.stdout.readline()
+            print("Server user is: %s" % line, end="", flush=True)
+
+
+##################################################################
+# tar example
+def cp_files(pod):
+    with pod.popen("/bin/tar", "cf", "-", "/etc", stdout=True) as popen:
+        with tarfile.TarFile.open(mode="r|", fileobj=popen.stdout) as archive:
+            archive.extractall("/tmp/popen")
+
+
+##################################################################
+# Full TTY integration running top, uses local posix apis and raw i/o.
+def top(pod):
+    with pod.popen("/bin/top", tty=True, stdin=True, stdout=True) as popen:
+        # Enable raw tty mode with no echoing or buffering
+        stdin = sys.stdin.fileno()
+        stdout = sys.stdout.fileno()
+        tcattr = termios.tcgetattr(stdin)
+        try:
+            tty.setraw(stdin)
+            size = None
+            # Do non-blocking stdout reads
+            popen.timeout = 0
+            while True:
+                resize = os.get_terminal_size()
+                if (
+                    not size
+                    or resize.columns != size.columns
+                    or resize.lines != size.lines
+                ):
+                    popen.resize(resize.columns, resize.lines)
+                    size = resize
+                    # Check if there is anything from our stdin
+                r, _, _ = select.select([stdin], [], [], 0)
+                if r:
+                    # Read from our stdin
+                    data = os.read(stdin, 1024)
+                    # Write it to remote top's stdin
+                    popen.stdin.write(data)
+                try:
+                    # Try to read from top's stdout
+                    data = popen.stdout.read(1024)
+                    # If a zero length data, then stdout has been closed
+                    if not data:
+                        # stdout was closed, now wait for top to finish.
+                        break
+                    # Write remote top's stdout to our stdout
+                    os.write(stdout, data)
+                except TimeoutError:
+                    # Nothing from stdout available at this time
+                    pass
+        finally:
+            # Restore the original tty attributes from raw mode
+            termios.tcsetattr(stdin, termios.TCSANOW, tcattr)
+        popen.timeout = None
+        popen.wait()
+
+
+def main():
+    pod = provision_pod(kr8s.api())
+    simple_response(pod)
+    stdin_sent(pod)
+    interactive(pod)
+    cp_files(pod)
+    top(pod)
+
+
+if __name__ == "__main__":
+    main()

--- a/kr8s/_api.py
+++ b/kr8s/_api.py
@@ -234,6 +234,24 @@ class Api:
         url: str = "",
         **kwargs,
     ) -> AsyncGenerator[httpx_ws.AsyncWebSocketSession]:
+        async with self.async_open_websocket(
+            version,
+            base,
+            namespace,
+            url,
+            **kwargs,
+        ) as websocket:
+            yield websocket
+
+    @contextlib.asynccontextmanager
+    async def async_open_websocket(
+        self,
+        version: str = "v1",
+        base: str = "",
+        namespace: str | None = None,
+        url: str = "",
+        **kwargs,
+    ) -> AsyncGenerator[httpx_ws.AsyncWebSocketSession]:
         """Open a websocket connection to a Kubernetes API endpoint."""
         if not self._session or self._session.is_closed:
             await self._create_session()

--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -88,27 +88,30 @@ class KubeAuth:
 
     async def ssl_context(self):
         async with self.__auth_lock:
-            if (
-                not self.client_key_file
-                and not self.client_cert_file
-                and not self.server_ca_file
-                and not self._insecure_skip_tls_verify
-            ):
-                # If no cert information is provided, fall back to default verification
-                return True
-            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            if self._insecure_skip_tls_verify:
-                sslcontext.check_hostname = False
-                sslcontext.verify_mode = ssl.CERT_NONE
-            if self.client_key_file and self.client_cert_file:
-                sslcontext.load_cert_chain(
-                    certfile=self.client_cert_file,
-                    keyfile=self.client_key_file,
-                    password=None,
-                )
-            if self.server_ca_file:
-                sslcontext.load_verify_locations(cafile=self.server_ca_file)
-            return sslcontext
+            return self._ssl_context()
+
+    def _ssl_context(self):
+        if (
+            not self.client_key_file
+            and not self.client_cert_file
+            and not self.server_ca_file
+            and not self._insecure_skip_tls_verify
+        ):
+            # If no cert information is provided, fall back to default verification
+            return True
+        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        if self._insecure_skip_tls_verify:
+            sslcontext.check_hostname = False
+            sslcontext.verify_mode = ssl.CERT_NONE
+        if self.client_key_file and self.client_cert_file:
+            sslcontext.load_cert_chain(
+                certfile=self.client_cert_file,
+                keyfile=self.client_key_file,
+                password=None,
+            )
+        if self.server_ca_file:
+            sslcontext.load_verify_locations(cafile=self.server_ca_file)
+        return sslcontext
 
     @property
     def namespace(self) -> str:

--- a/kr8s/_exec.py
+++ b/kr8s/_exec.py
@@ -2,24 +2,18 @@
 # SPDX-License-Identifier: BSD 3-Clause License
 from __future__ import annotations
 
-import json
+import functools
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, BinaryIO
 
+import anyio
+
 from kr8s._exceptions import ExecError
 
 if TYPE_CHECKING:
     from kr8s._objects import APIObject
-
-STDIN_CHANNEL: int = 0
-STDOUT_CHANNEL: int = 1
-STDERR_CHANNEL: int = 2
-ERROR_CHANNEL: int = 3
-RESIZE_CHANNEL: int = 4
-CLOSE_CHANNEL: int = 255
-EXEC_PROTOCOL: str = "v4.channel.k8s.io"
 
 
 class Exec:
@@ -28,9 +22,9 @@ class Exec:
     def __init__(
         self,
         resource: APIObject,
-        command: list[str],
+        command: str | list[str],
         container: str | None = None,
-        stdin: str | BinaryIO | None = None,
+        stdin: bytes | str | BinaryIO | None = None,
         stdout: BinaryIO | None = None,
         stderr: BinaryIO | None = None,
         check: bool = True,
@@ -46,75 +40,75 @@ class Exec:
         self._capture_output = capture_output
         self._timeout = timeout
 
-        self.args = command
-        self.stdout = b""
-        self.stderr = b""
-        self.returncode: int
-        self.check = check
+        self.args: str | list[str] = command
+        self.stdout: bytes = b""
+        self.stderr: bytes = b""
+        self.returncode: int | None = None
+        self.check: bool = check
 
     @asynccontextmanager
     async def run(
         self,
     ) -> AsyncGenerator[Exec, CompletedExec]:
         assert self._resource.api
-        async with self._resource.api.open_websocket(
-            version=self._resource.version,
-            url=f"{self._resource.endpoint}/{self._resource.name}/exec",
-            subprotocols=(EXEC_PROTOCOL,),
-            namespace=self._resource.namespace,
-            params={
-                "command": self.args,
-                "container": self._container or self._resource.spec.containers[0].name,
-                "stdout": "true" if self._stdout or self._capture_output else "false",
-                "stderr": "true" if self._stderr or self._capture_output else "false",
-                "stdin": "true" if self._stdin is not None else "false",
-            },
-        ) as ws:
-            if self._stdin:
-                if ws.subprotocol != "v5.channel.k8s.io":
-                    raise ExecError(
-                        "Stdin is not supported with protocol "
-                        f"{ws.subprotocol}, only with v5.channel.k8s.io"
-                    )
-                if isinstance(self._stdin, str):
-                    await ws.send_bytes(STDIN_CHANNEL.to_bytes() + self._stdin.encode())  # type: ignore
-                else:
-                    await ws.send_bytes(STDIN_CHANNEL.to_bytes() + self._stdin.read())  # type: ignore
-                await ws.send_bytes(CLOSE_CHANNEL.to_bytes() + STDIN_CHANNEL.to_bytes())  # type: ignore
-            while True:
-                message = await ws.receive_bytes(timeout=self._timeout)
-                channel, message = int(message[0]), message[1:]
-                if message:
-                    if channel == STDOUT_CHANNEL:
-                        if self._capture_output:
-                            self.stdout += message
-                        if self._stdout:
-                            self._stdout.write(message)
-                    elif channel == STDERR_CHANNEL:
-                        if self._capture_output:
-                            self.stderr += message
-                        if self._stderr:
-                            self._stderr.write(message)
-                    elif channel == ERROR_CHANNEL:
-                        error = json.loads(message.decode())
-                        if error["status"] == "Success":
-                            self.returncode = 0
-                            break
-                        # Extract return code from details
-                        if "details" in error and "causes" in error["details"]:
-                            for cause in error["details"]["causes"]:
-                                if "reason" in cause and cause["reason"] == "ExitCode":
-                                    self.returncode = int(cause["message"])
-                                    break
-                        else:
-                            self.returncode = 1
-                        if self.check:
-                            raise ExecError(error["message"])
-                        break
-                    else:
-                        raise ExecError(
-                            f"Unhandled message on channel {channel}: {message}"
-                        )
+
+        async with self._resource.async_popen(
+            *self.args,
+            container=self._container,
+            stdin=self._stdin is not None,
+            stdout=bool(self._capture_output or self._stdout),
+            stderr=bool(self._capture_output or self._stderr),
+            timeout=self._timeout,
+        ) as popen:
+            stdin = self._stdin
+            if stdin is not None and popen.stdin:
+                if isinstance(stdin, str):
+                    stdin = stdin.encode()
+                elif isinstance(stdin, BinaryIO):
+                    stdin = stdin.read()
+                await popen.stdin.send(stdin)
+                await popen.stdin.aclose()
+            output = bytearray()
+            error = bytearray()
+
+            async def receive(stream, output, buffer):
+                async for chunk in stream:
+                    if output:
+                        output.write(chunk)
+                    if buffer is not None:
+                        buffer.extend(chunk)
+
+            stdout_receive = functools.partial(
+                receive,
+                popen.stdout,
+                self._stdout,
+                output if self._capture_output else None,
+            )
+            stderr_receive = functools.partial(
+                receive,
+                popen.stderr,
+                self._stderr,
+                error if self._capture_output else None,
+            )
+            if self._capture_output or (self._stdout and self._stderr):
+                async with anyio.create_task_group() as group:
+                    group.start_soon(stdout_receive)
+                    group.start_soon(stderr_receive)
+            elif self._stdout:
+                await stdout_receive()
+            elif self._stderr:
+                await stderr_receive()
+            await popen.wait()
+            self.stdout = bytes(output)
+            self.stderr = bytes(error)
+            self.returncode = popen.returncode
+            if self.returncode:
+                if self.returncode < 0:
+                    self.returncode = 1
+                if self.check:
+                    if isinstance(popen.result, dict) and "message" in popen.result:
+                        raise ExecError(popen.result["message"])
+                    raise ExecError(popen.result)
             yield self
 
     async def wait(self) -> CompletedExec:
@@ -139,7 +133,7 @@ class CompletedExec:
     args: str | list[str]
     stdout: bytes
     stderr: bytes
-    returncode: int
+    returncode: int | None
 
     def check_returncode(self) -> None:
         if self.returncode != 0:

--- a/kr8s/_popen.py
+++ b/kr8s/_popen.py
@@ -1,0 +1,427 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+from __future__ import annotations
+
+import collections
+import enum
+import functools
+import json
+import queue
+import time
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import anyio.abc
+import anyio.streams.buffered
+import anyio.streams.text
+import httpx_ws
+
+from kr8s._exceptions import ConnectionClosedError, ExecError
+
+if TYPE_CHECKING:
+    from kr8s._objects import APIObject, Pod
+
+
+STDIN_CHANNEL: bytes = bytes([0])
+STDOUT_CHANNEL: int = 1
+STDERR_CHANNEL: int = 2
+ERROR_CHANNEL: int = 3
+RESIZE_CHANNEL: bytes = bytes([4])
+CLOSE_CHANNEL: bytes = bytes([255])
+
+
+class _NotSet(enum.Enum):
+    NOT_SET = object()
+
+
+_NOT_SET = _NotSet.NOT_SET
+
+
+class Popen:
+    """Executes a command in a running container returning a subprocess.Popen like object."""
+
+    def __init__(
+        self,
+        resource: APIObject,
+        *command: str,
+        container: str | None = None,
+        tty: bool | None = None,
+        buffer: bool | None = None,
+        text: bool | None = None,
+        encoding: str | None = None,
+        errors: str | None = None,
+        stdin: bool | int | None = None,
+        stdout: bool | None = None,
+        stderr: bool | None = None,
+        stderr2out: bool | None = None,
+        timeout: int | None = None,
+    ):
+        self.resource: APIObject = resource
+        self.pod: Pod | None = None
+        self._container: str | None = container
+        self.container: str | None = None
+        self.command: tuple[str, ...] = command
+        self.tty: bool = bool(tty)
+        self.buffer: bool = bool(buffer)
+        self.text: bool = bool(text)
+        self.encoding: str | None = encoding
+        self.error: str | None = errors
+        self.stdin: anyio.abc.ByteSendStream | None = None
+        self.stdout: anyio.abc.ByteReceiveStream | None = None
+        self.stderr: anyio.abc.ByteReceiveStream | None = None
+        self.result: dict | str | None = None
+        self.returncode: int | None = None
+
+        text_kwargs = {}
+        if encoding:
+            text_kwargs["encoding"] = encoding
+        if errors:
+            text_kwargs["errors"] = errors
+        if stdin:
+            self.stdin = self._Stdin(self)
+            if self.text:
+                self.stdin = anyio.streams.text.TextSendStream(
+                    self.stdin, **text_kwargs
+                )
+
+        self._stdout_raw = None
+        self._stderr_raw = None
+        if stdout or stderr2out:
+            self.stdout = self._stdout_raw = self._Stdout(self)
+            if self.buffer:
+                self.stdout = anyio.streams.buffered.BufferedByteReceiveStream(
+                    self.stdout
+                )
+            if self.text:
+                self.stdout = anyio.streams.text.TextReceiveStream(
+                    self.stdout, **text_kwargs
+                )
+            if stderr2out:
+                self._stderr_raw = self._stdout_raw
+                if not stdout:
+                    self._stdout_raw = None
+        if stderr:
+            if stderr2out:
+                raise ValueError("stderr and stderr2out cannot be specified")
+            self.stderr = self._stderr_raw = self._Stdout(self)
+            if self.buffer:
+                self.stderr = anyio.streams.buffered.BufferedByteReceiveStream(
+                    self.stderr
+                )
+            if self.text:
+                self.stderr = anyio.streams.text.TextReceiveStream(
+                    self.stderr, **text_kwargs
+                )
+        self.timeout: int | None = timeout
+        self._enter_task = None
+        self._websocket = None
+        self._recv_data_lock = anyio.Lock()
+        self._frame_count = 0
+
+    @property
+    def timeout(self) -> float | None:
+        """Timeout from now of all subsequest reads of stdout and stderr.
+
+        Returns 0 for non-blocking reads and returns None for blocking reads.
+        """
+        if self._timeout is None:
+            return None
+        now = time.time()
+        if now >= self._timeout:
+            return 0.1
+        return self._timeout - now
+
+    @timeout.setter
+    def timeout(self, timeout: int | float | None):
+        if timeout is None:
+            self._timeout = None
+        else:
+            if not isinstance(timeout, (int, float)):
+                raise TypeError("timeout is not a number")
+            self._timeout = time.time() + timeout
+
+    @property
+    def closed(self):
+        return not self._websocket
+
+    async def __aenter__(self):
+        self._enter_task = self._async_enter()
+        return await self._enter_task.__aenter__()
+
+    async def __aexit__(self, *args, **kwargs) -> None:
+        assert self._enter_task
+        return await self._enter_task.__aexit__(*args, **kwargs)
+
+    async def resize(self, width: int, height: int):
+        """Inform the remote process the size of the TTY screen."""
+        if self._websocket:
+            resize = f'{{"Width":{width},"Height":{height}}}'.encode()
+            await self._websocket.send_bytes(RESIZE_CHANNEL + resize)
+
+    async def communicate(
+        self,
+        input: bytes | str | None = None,
+        timeout: int | float | None | _NotSet = _NOT_SET,
+    ) -> list[bytes | str | None]:
+        """Interact with process: Send data to stdin and close it.
+
+        Read data from stdout and stderr, until end-of-file is
+        reached. Wait for process to terminate.
+
+        The optional "input" argument should be data to be sent to the
+        child process, or None, if no data should be sent to the child.
+        communicate() returns a list [stdout, stderr].
+
+        By default, all communication is in bytes, and therefore any
+        "input" should be bytes, and the (stdout, stderr) will be bytes.
+        If in text mode (indicated by self.text), any "input" should
+        be a string, and [stdout, stderr] will be strings decoded
+        according to locale encoding, or by "encoding" if set.
+        """
+        if self.closed:
+            raise ValueError("Cannot call communicate after websocket close")
+        if timeout is not _NOT_SET:
+            self.timeout = timeout
+        try:
+            if self.stdin:
+                if input:
+                    await self.stdin.send(input)
+                await self.stdin.aclose()
+            results = [None, None]
+            if self.stdout or self.stderr:
+                if self.text:
+                    initialize = list  # type: ignore
+                    append = "append"
+
+                    def finalize(result):
+                        return "".join(result)
+
+                else:
+                    initialize = bytearray  # type: ignore
+                    append = "extend"
+                    finalize = bytes
+
+                async def receive(initialize, append, finalize, results, ix, stream):
+                    result = initialize()
+                    append = getattr(result, append)
+                    async for chunk in stream:
+                        append(chunk)
+                    results[ix] = finalize(result)
+
+                receive = functools.partial(
+                    receive, initialize, append, finalize, results
+                )
+                stdout_receive = functools.partial(receive, 0, self.stdout)
+                stderr_receive = functools.partial(receive, 1, self.stderr)
+                if self.stdout:
+                    if self.stderr:
+                        async with anyio.create_task_group() as group:
+                            group.start_soon(stdout_receive)
+                            group.start_soon(stderr_receive)
+                    else:
+                        await stdout_receive()
+                elif self.stderr:
+                    await stderr_receive()
+            await self.wait()
+            return results  # type: ignore
+        finally:
+            await self.close()
+
+    async def wait(
+        self, timeout: int | float | None | _NotSet = _NOT_SET
+    ) -> int | None:
+        """Wait for child process to terminate; returns self.returncode."""
+        if self.closed:
+            return None
+        if timeout is not _NOT_SET:
+            self.timeout = timeout
+        try:
+            if self.stdin:
+                await self.stdin.aclose()
+            if self.stdout:
+                await self.stdout.aclose()
+            if self.stderr:
+                await self.stderr.aclose()
+            while True:
+                status = await self._recv_data_frame()
+                if not status:
+                    if status is None:
+                        raise TimeoutError()
+                    return self.returncode
+        finally:
+            await self.close()
+
+    async def close(self):
+        if self._websocket:
+            await self._websocket.close()
+            self._websocket = None
+
+    @asynccontextmanager
+    async def _async_enter(self) -> AsyncGenerator[Popen]:
+        from kr8s._objects import Pod
+
+        stdin = bool(self.stdin)
+        # kubelet thinks at least one stream must be specified
+        if not stdin and not self._stdout_raw and not self._stderr_raw:
+            stdin = True
+        connection_attempts = 0
+        while True:
+            if isinstance(self.resource, Pod):
+                self.pod = self.resource
+            else:
+                if not hasattr(self.resource, "async_ready_pods"):
+                    raise NotImplementedError(
+                        f"{self.resource.kind} does not support exec"
+                    )
+                pods = await self.resource.async_ready_pods()  # type: ignore
+                if not pods:
+                    raise RuntimeError("No ready pods found")
+                self.pod = pods[connection_attempts % len(pods)]
+            if self._container:
+                self.container = self._container
+            else:
+                try:
+                    self.container = self.pod.annotations[
+                        "kubectl.kubernetes.io/default-container"
+                    ]
+                except KeyError:
+                    self.container = self.pod.spec.containers[0].name
+            try:
+                assert self.pod.api
+                async with self.pod.api.async_open_websocket(
+                    version=self.pod.version,
+                    url=f"{self.pod.endpoint}/{self.pod.name}/exec",
+                    subprotocols=(
+                        "v5.channel.k8s.io",
+                        "v4.channel.k8s.io",
+                    ),
+                    namespace=self.pod.namespace,
+                    params={
+                        "container": self.container,
+                        "command": self.command,
+                        "tty": str(self.tty).lower(),
+                        "stdin": str(stdin).lower(),
+                        "stdout": str(bool(self._stdout_raw)).lower(),
+                        "stderr": str(bool(self._stderr_raw)).lower(),
+                    },
+                ) as websocket:
+                    if stdin:
+                        if self.stdin:
+                            if websocket.subprotocol != "v5.channel.k8s.io":
+                                raise ExecError(
+                                    "stdin is not supported with Kubernetes versions less than 1.30"
+                                )
+                        else:
+                            if websocket.subprotocol == "v5.channel.k8s.io":
+                                await websocket.send_bytes(
+                                    CLOSE_CHANNEL + STDIN_CHANNEL
+                                )
+                    self._websocket = websocket
+                    yield self
+                    await self.close()
+                    return
+            except httpx_ws.HTTPXWSException as ex:
+                self.pod = None
+                self.container = None
+                connection_attempts += 1
+                if connection_attempts > 5:
+                    raise ConnectionClosedError("Unable to connect to Pod") from ex
+                await anyio.sleep(0.2 * connection_attempts)
+
+    class _Stdin(anyio.abc.ByteSendStream):
+        def __init__(self, popen):
+            self.closed = False
+            self._popen = popen
+
+        async def send(self, item: bytes) -> None:
+            if not self.closed and not self._popen.closed:
+                await self._popen._websocket.send_bytes(STDIN_CHANNEL + item)
+
+        async def aclose(self) -> None:
+            if not self.closed:
+                self.closed = True
+                if (
+                    not self._popen.closed
+                    and self._popen._websocket.subprotocol == "v5.channel.k8s.io"
+                ):
+                    await self._popen._websocket.send_bytes(
+                        CLOSE_CHANNEL + STDIN_CHANNEL
+                    )
+
+    class _Stdout(anyio.abc.ByteReceiveStream):
+        def __init__(self, popen):
+            self.closed = False
+            self._popen = popen
+            self._frames = collections.deque()
+            self._ix = 1
+
+        async def receive(self, max_size: int = 65536) -> bytes:
+            if self.closed:
+                raise anyio.EndOfStream()
+            while not self._frames:
+                status = await self._popen._recv_data_frame()
+                if not status:
+                    if status is None:
+                        raise TimeoutError()
+                    raise anyio.EndOfStream()
+            if len(self._frames[0]) - self._ix <= max_size:
+                data = self._frames[0][self._ix :]
+                self._frames.popleft()
+                self._ix = 1
+            else:
+                data = self._frames[0][self._ix : self._ix + max_size]
+                self._ix += max_size
+            return data
+
+        async def aclose(self) -> None:
+            self.closed = True
+            self._frames.clear()
+            self._ix = 1
+
+    async def _recv_data_frame(self):
+        # Returns True if frame read, False if websocket is closed,
+        # and None if timeed out with no frames read.
+        count = self._frame_count
+        async with self._recv_data_lock:
+            if count != self._frame_count:
+                return True
+            if self.closed:
+                return False
+            try:
+                frame = await self._websocket.receive_bytes(timeout=self.timeout)
+            except (TimeoutError, queue.Empty):
+                return None
+            except httpx_ws.WebSocketDisconnect:
+                await self.close()
+                if self.returncode is None:
+                    self.returncode = -4
+                return False
+            channel = frame[0]
+            if channel == STDOUT_CHANNEL:
+                if self._stdout_raw and not self._stdout_raw.closed and len(frame) > 1:
+                    self._stdout_raw._frames.append(frame)
+                self._frame_count += 1
+                return True
+            if channel == STDERR_CHANNEL:
+                if self._stderr_raw and not self._stderr_raw.closed and len(frame) > 1:
+                    self._stderr_raw._frames.append(frame)
+                self._frame_count += 1
+                return True
+            if channel == ERROR_CHANNEL:
+                if len(frame) > 2 and frame[1] == ord("{") and frame[-1] == ord("}"):
+                    self.result = json.loads(frame[1:])
+                    if self.result.get("status") == "Success":
+                        self.returncode = 0
+                    else:
+                        for cause in self.result.get("details", {}).get("causes", []):
+                            if cause.get("reason") == "ExitCode":
+                                self.returncode = int(cause.get("message", -3))
+                                break
+                        else:
+                            self.returncode = -2
+                else:
+                    self.result = frame[1:].decode()
+                    self.returncode = -1
+                await self.close()
+                return False

--- a/kr8s/_portforward.py
+++ b/kr8s/_portforward.py
@@ -224,7 +224,7 @@ class PortForward:
                 self.pod = await self._select_pod()
             try:
                 assert self.pod.api
-                async with self.pod.api.open_websocket(
+                async with self.pod.api.async_open_websocket(
                     version=self.pod.version,
                     url=f"{self.pod.endpoint}/{self.pod.name}/portforward",
                     namespace=self.pod.namespace,
@@ -239,6 +239,7 @@ class PortForward:
                     break
             except httpx_ws.HTTPXWSException as e:
                 self.pod = None
+                connection_attempts += 1
                 if connection_attempts > 5:
                     raise ConnectionClosedError("Unable to connect to Pod") from e
                 await anyio.sleep(0.1 * connection_attempts)

--- a/kr8s/asyncio/popen.py
+++ b/kr8s/asyncio/popen.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+"""Objects for managing a subprocess.Popen like pod exec functionality.
+
+This module provides a class for exec'ing processes on clusters using a subprocess.Popen like object.
+"""
+
+from kr8s._popen import Popen
+
+__all__ = ["Popen"]

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -21,7 +21,7 @@ DEFAULT_LABELS = {"created-by": "kr8s-tests"}
 
 
 @pytest.fixture(scope="session")
-def pause_image():
+def pause_image() -> str:
     return "registry.k8s.io/pause:3.9"
 
 

--- a/kr8s/objects.py
+++ b/kr8s/objects.py
@@ -233,7 +233,7 @@ class Pod(APIObjectSyncMixin, _Pod):
 
     def exec(  # type: ignore[override]
         self,
-        command: list[str],
+        command: str | list[str],
         *,
         container: str | None = None,
         stdin: str | BinaryIO | None = None,

--- a/kr8s/popen.py
+++ b/kr8s/popen.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, Kr8s Developers (See LICENSE for list)
+# SPDX-License-Identifier: BSD 3-Clause License
+"""Objects for managing a port forward connection.
+
+This module provides a class for managing a port forward connection to a Kubernetes Pod or Service.
+"""
+
+# Disable missing docstrings, these are inherited from the async version of the objects
+# ruff: noqa: D102, D105
+from __future__ import annotations
+
+import io
+import json
+import queue
+import threading
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+import httpx_ws
+
+from kr8s._exceptions import ConnectionClosedError, ExecError
+from kr8s._popen import (
+    _NOT_SET,
+    CLOSE_CHANNEL,
+    ERROR_CHANNEL,
+    RESIZE_CHANNEL,
+    STDERR_CHANNEL,
+    STDIN_CHANNEL,
+    STDOUT_CHANNEL,
+    _NotSet,
+)
+
+if TYPE_CHECKING:
+    from kr8s._objects import APIObject
+    from kr8s.objects import Pod
+
+
+__all__ = ["Popen"]
+
+
+class Popen:
+    """Executes a command in a running container returning a subprocess.Popen like object."""
+
+    def __init__(
+        self,
+        resource: APIObject,
+        *command: str,
+        container: str | None = None,
+        tty: bool | None = None,
+        buffer: bool | None = None,
+        text: bool | None = None,
+        encoding: str | None = None,
+        errors: str | None = None,
+        stdin: bool | int | None = None,
+        stdout: bool | None = None,
+        stderr: bool | None = None,
+        stderr2out: bool | None = None,
+        timeout: int | None = None,
+    ):
+        """Executes a command in a running container returning a subprocess.Popen like object."""
+        self.resource: APIObject = resource
+        self.pod: Pod | None = None
+        self._container: str | None = container
+        self.container: str | None = None
+        self.command: tuple[str, ...] = command
+        self.tty: bool = bool(tty)
+        self.buffer: bool = bool(buffer)
+        self.text: bool = bool(text)
+        self.encoding: str | None = encoding
+        self.error: str | None = errors
+        self.stdin: io.RawIOBase | None = None
+        self.stdout: io.RawIOBase | None = None
+        self.stderr: io.RawIOBase | None = None
+        self.result: dict | str | None = None
+        self.returncode: int | None = None
+
+        text_kwargs = {}
+        if encoding:
+            text_kwargs["encoding"] = encoding
+        if errors:
+            text_kwargs["errors"] = errors
+        if stdin:
+            self.stdin = self._Stdin(self)
+            if self.text:
+                self.stdin = io.TextIOWrapper(  # type: ignore
+                    self.stdin,
+                    encoding=encoding,
+                    errors=errors,
+                    line_buffering=self.buffer,
+                    write_through=True,
+                )
+        self._stdout_raw = None
+        self._stderr_raw = None
+        if stdout or stderr2out:
+            self.stdout = self._stdout_raw = self._Stdout(self)
+            if self.buffer:
+                self.stdout = io.BufferedReader(self._stdout_raw)  # type: ignore
+            if self.text:
+                self.stdout = io.TextIOWrapper(  # type: ignore
+                    self.stdout, encoding=encoding, errors=errors
+                )
+            if stderr2out:
+                self._stderr_raw = self._stdout_raw
+                if not stdout:
+                    self._stdout_raw = None
+        if stderr:
+            if stderr2out:
+                raise ValueError("stderr and stderr2out cannot be specified")
+            self.stderr = self._stderr_raw = self._Stdout(self)
+            if self.buffer:
+                self.stderr = io.BufferedReader(self._stderr_raw)  # type: ignore
+            if self.text:
+                self.stderr = io.TextIOWrapper(  # type: ignore
+                    self.stderr, encoding=encoding, errors=errors
+                )
+        self.timeout = timeout
+        self._enter_task = None
+        self._websocket = None
+        self._recv_data_lock = threading.Lock()
+        self._frame_count = 0
+
+    @property
+    def timeout(self) -> float | None:
+        """Timeout from now of all subsequest reads of stdout and stderr.
+
+        Returns 0 for non-blocking reads and returns None for blocking reads.
+        """
+        if self._timeout is None:
+            return None
+        now = time.time()
+        if now >= self._timeout:
+            return 0.1
+        return self._timeout - now
+
+    @timeout.setter
+    def timeout(self, timeout: int | float | None):
+        if timeout is None:
+            self._timeout = None
+        else:
+            if not isinstance(timeout, (int, float)):
+                raise TypeError("timeout is not a number")
+            self._timeout = time.time() + timeout
+
+    @property
+    def closed(self):
+        return not self._websocket
+
+    def __enter__(self):
+        self._enter_task = self._enter()
+        return self._enter_task.__enter__()
+
+    def __exit__(self, *args, **kwargs) -> None:
+        assert self._enter_task
+        return self._enter_task.__exit__(*args, **kwargs)
+
+    def resize(self, width: int, height: int):
+        """Inform the remote process the size of the TTY screen."""
+        if self._websocket:
+            resize = f'{{"Width":{width},"Height":{height}}}'.encode()
+            self._websocket.send_bytes(RESIZE_CHANNEL + resize)
+
+    def communicate(
+        self,
+        input: bytes | str | None = None,
+        timeout: int | float | None | _NotSet = _NOT_SET,
+    ) -> list[bytes | str | None]:
+        """Interact with process: Send data to stdin and close it.
+
+        Read data from stdout and stderr, until end-of-file is
+        reached. Wait for process to terminate.
+
+        The optional "input" argument should be data to be sent to the
+        child process, or None, if no data should be sent to the child.
+        communicate() returns a list [stdout, stderr].
+
+        By default, all communication is in bytes, and therefore any
+        "input" should be bytes, and the (stdout, stderr) will be bytes.
+        If in text mode (indicated by self.text), any "input" should
+        be a string, and [stdout, stderr] will be strings decoded
+        according to locale encoding, or by "encoding" if set.
+        """
+        if self.closed:
+            raise ValueError("Cannot call communicate after websocket close")
+        if timeout is not _NOT_SET:
+            self.timeout = timeout
+        try:
+            if self.stdin:
+                if input:
+                    self.stdin.write(input)  # type: ignore
+                self.stdin.close()
+            if self.stdout:
+                stdout = self.stdout.read()
+                self.stdout.close()
+            else:
+                stdout = None
+            if self.stderr:
+                stderr = self.stderr.read()
+                self.stderr.close()
+            else:
+                stderr = None
+            self.wait()
+            return [stdout, stderr]
+        finally:
+            self.close()
+
+    def wait(self, timeout: int | float | None | _NotSet = _NOT_SET) -> int | None:
+        """Wait for child process to terminate; returns self.returncode."""
+        if self.closed:
+            return None
+        if timeout is not _NOT_SET:
+            self.timeout = timeout
+        try:
+            if self.stdout:
+                self.stdout.close()
+            if self.stderr:
+                self.stderr.close()
+            while True:
+                status = self._recv_data_frame()
+                if not status:
+                    if status is None:
+                        raise TimeoutError()
+                    return self.returncode
+        finally:
+            self.close()
+
+    def close(self):
+        if self._websocket:
+            self._websocket.close()
+            self._websocket = None
+
+    @contextmanager
+    def _enter(self) -> Generator[Popen]:
+        from kr8s.objects import Pod
+
+        stdin = bool(self.stdin)
+        # kubelet thinks at least one stream must be specified
+        if not stdin and not self._stdout_raw and not self._stderr_raw:
+            stdin = True
+        connection_attempts = 0
+        while True:
+            if isinstance(self.resource, Pod):
+                self.pod = self.resource
+            else:
+                if not hasattr(self.resource, "ready_pods"):
+                    raise NotImplementedError(
+                        f"{self.resource.kind} does not support exec"
+                    )
+                pods = self.resource.ready_pods()  # type: ignore
+                if not pods:
+                    raise RuntimeError("No ready pods found")
+                self.pod = pods[connection_attempts % len(pods)]
+            if self._container:
+                self.container = self._container
+            else:
+                try:
+                    assert self.pod
+                    self.container = self.pod.annotations[
+                        "kubectl.kubernetes.io/default-container"
+                    ]
+                except KeyError:
+                    self.container = self.pod.spec.containers[0].name
+            try:
+                assert self.pod.api
+                with self.pod.api.open_websocket(
+                    version=self.pod.version,
+                    url=f"{self.pod.endpoint}/{self.pod.name}/exec",
+                    subprotocols=(
+                        "v5.channel.k8s.io",
+                        "v4.channel.k8s.io",
+                    ),
+                    namespace=self.pod.namespace,
+                    params={
+                        "container": self.container,
+                        "command": self.command,
+                        "tty": str(self.tty).lower(),
+                        "stdin": str(stdin).lower(),
+                        "stdout": str(bool(self._stdout_raw)).lower(),
+                        "stderr": str(bool(self._stderr_raw)).lower(),
+                    },
+                ) as websocket:
+                    if stdin:
+                        if self.stdin:
+                            if websocket.subprotocol != "v5.channel.k8s.io":
+                                raise ExecError(
+                                    "stdin is not supported with Kubernetes versions less than 1.30"
+                                )
+                        else:
+                            if websocket.subprotocol == "v5.channel.k8s.io":
+                                websocket.send_bytes(CLOSE_CHANNEL + STDIN_CHANNEL)
+                    self._websocket = websocket
+                    yield self
+                    self.close()
+                    return
+            except httpx_ws.HTTPXWSException as ex:
+                self.pod = None
+                self.container = None
+                connection_attempts += 1
+                if connection_attempts > 5:
+                    raise ConnectionClosedError("Unable to connect to Pod") from ex
+                time.sleep(0.2 * connection_attempts)
+
+    class _Stdin(io.RawIOBase):
+        def __init__(self, popen):
+            super().__init__()
+            self._popen = popen
+
+        def writable(self):
+            return True
+
+        def write(self, b):
+            if self._popen.closed:
+                return 0
+            self._popen._websocket.send_bytes(STDIN_CHANNEL + b)
+            return len(b)
+
+        def close(self):
+            super().close()
+            if (
+                not self._popen.closed
+                and self._popen._websocket.subprotocol == "v5.channel.k8s.io"
+            ):
+                self._popen._websocket.send_bytes(CLOSE_CHANNEL + STDIN_CHANNEL)
+
+    class _Stdout(io.RawIOBase):
+        def __init__(self, popen):
+            super().__init__()
+            self._popen = popen
+            self._frames = []
+            self._ix = 1
+
+        def readable(self):
+            return True
+
+        def readinto(self, b):
+            while not self._frames:
+                status = self._popen._recv_data_frame()
+                if not status:
+                    if status is None:
+                        raise TimeoutError()
+                    return 0
+            size = len(self._frames[0]) - self._ix
+            if size <= len(b):
+                b[:size] = self._frames[0][self._ix :]
+                del self._frames[0]
+                self._ix = 1
+            else:
+                size = len(b)
+                b[:] = self._frames[0][self._ix : self._ix + size]
+                self._ix += size
+            return size
+
+        def close(self):
+            super().close()
+            self._frames = []
+            self._ix = 1
+
+    def _recv_data_frame(self):
+        # Returns True if frame read, False if websocket is closed,
+        # and None if timeed out with no frames read.
+        count = self._frame_count
+        with self._recv_data_lock:
+            if count != self._frame_count:
+                return True
+            if self.closed:
+                return False
+            try:
+                frame = self._websocket.receive_bytes(timeout=self.timeout)
+            except (TimeoutError, queue.Empty):
+                return None
+            except httpx_ws.WebSocketDisconnect:
+                self.close()
+                if self.returncode is None:
+                    self.returncode = -4
+                return False
+            channel = frame[0]
+            if channel == STDOUT_CHANNEL:
+                if self._stdout_raw and not self._stdout_raw.closed and len(frame) > 1:
+                    self._stdout_raw._frames.append(frame)
+                self._frame_count += 1
+                return True
+            if channel == STDERR_CHANNEL:
+                if self._stderr_raw and not self._stderr_raw.closed and len(frame) > 1:
+                    self._stderr_raw._frames.append(frame)
+                self._frame_count += 1
+                return True
+            if channel == ERROR_CHANNEL:
+                if len(frame) > 2 and frame[1] == ord("{") and frame[-1] == ord("}"):
+                    self.result = json.loads(frame[1:])
+                    if self.result.get("status") == "Success":
+                        self.returncode = 0
+                    else:
+                        for cause in self.result.get("details", {}).get("causes", []):
+                            if cause.get("reason") == "ExitCode":
+                                self.returncode = int(cause.get("message", -3))
+                                break
+                        else:
+                            self.returncode = -2
+                else:
+                    self.result = frame[1:].decode()
+                    self.returncode = -1
+                self.close()
+                return False

--- a/kr8s/tests/test_objects.py
+++ b/kr8s/tests/test_objects.py
@@ -1146,10 +1146,15 @@ async def test_pod_exec_to_file(ubuntu_pod):
         assert b"invalid date" in tmp.read()
 
 
-@pytest.mark.xfail(reason="Exec protocol v5.channel.k8s.io not available")
-async def test_pod_exec_stdin(ubuntu_pod):
-    ex = await ubuntu_pod.exec(["cat"], stdin="foo")
-    assert b"foo" in ex.stdout
+async def test_pod_exec_stdin(kubernetes_version, ubuntu_pod):
+    if kubernetes_version < [1, 30]:
+        with pytest.raises(ExecError):
+            await ubuntu_pod.exec(["cat"], stdin="foo")
+    else:
+        ex = await ubuntu_pod.exec(["cat"], stdin="foo")
+        assert b"foo" == ex.stdout
+        assert ex.stderr == b""
+        assert ex.returncode == 0
 
 
 async def test_pod_exec_not_ready(ns):


### PR DESCRIPTION
This is very much a POC, but I believe the functionality is all there. The examples directory has a set of both async and sync examples. I created this Draft PR to get some initial feed back on the direction before doing serious polishing of the code, such as proper unit tests.

Async examples: https://github.com/iciclespider/kr8s/blob/exec-popen/examples/exec_popen.py
Sync examples: https://github.com/iciclespider/kr8s/blob/exec-popen/examples/exec_popen_sync.py

I did run into issues with sync vs async that required creating stand alone sync and async implementations. This is because the sync to async support only works for single purpose calls, but this creates the Popen object inside a context manager that then performs api calls. I am very much open to creative solutions.

Another issue is the stdin, stdout, and stderr field expose different methods in sync vs async. I would like to come up with a common set of methods, but am not sure if the sync or the async flavor should be the target.

I implemented a sync version of api.open_websocket and made a best guess on what to do. It is functional, but not very clean.

Related Issues:
* https://github.com/kr8s-org/kr8s/issues/210
* https://github.com/kr8s-org/kr8s/issues/212
* https://github.com/kr8s-org/kr8s/issues/342