### PR TITLE
Ensure service accounts read namespace

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -287,7 +287,8 @@ class KubeAuth:
             if old_token != self.token:
                 logger.debug("Found new token")
         self.server_ca_file = os.path.join(self._serviceaccount, "ca.crt")
-        if self.namespace is None:
+        # Skip the namespace getter to check if the value is still the default
+        if self._namespace is None:
             async with await anyio.open_file(
                 os.path.join(self._serviceaccount, "namespace")
             ) as f:

--- a/kr8s/conftest.py
+++ b/kr8s/conftest.py
@@ -201,7 +201,7 @@ def k8s_token(k8s_cluster):
 
 
 @pytest.fixture
-def serviceaccount(k8s_cluster, k8s_token):
+def serviceaccount(k8s_cluster, k8s_token, ns):
     # Load kubeconfig
     kubeconfig = yaml.safe_load(k8s_cluster.kubeconfig_path.read_text())
 
@@ -221,9 +221,8 @@ def serviceaccount(k8s_cluster, k8s_token):
                 kubeconfig["clusters"][0]["cluster"]["certificate-authority-data"]
             ).decode()
         )
-        namespace = "default"
         (tempdir / "token").write_text(k8s_token)
-        (tempdir / "namespace").write_text(namespace)
+        (tempdir / "namespace").write_text(ns)
         yield str(tempdir)
 
 


### PR DESCRIPTION
Closes #740 

It looks like the namespace isn't being read from the service account for some reason. The value tested in the test case matches the default value, so the test isn't actually checking if the correct value is being read.

This PR ensures that the correct namespace is read when namespace is omitted.