### PR TITLE
Make service account env vars optional

### DIFF
--- a/kr8s/_auth.py
+++ b/kr8s/_auth.py
@@ -276,8 +276,8 @@ class KubeAuth:
         if not os.path.isdir(self._serviceaccount):
             return
         self.server = self._format_server_address(
-            os.environ["KUBERNETES_SERVICE_HOST"],
-            os.environ["KUBERNETES_SERVICE_PORT"],
+            os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc"),
+            os.environ.get("KUBERNETES_SERVICE_PORT", "443"),
         )
         async with await anyio.open_file(
             os.path.join(self._serviceaccount, "token")

--- a/kr8s/_testutils.py
+++ b/kr8s/_testutils.py
@@ -36,3 +36,36 @@ def set_env(**environ: str) -> Generator[None, None, None]:
     finally:
         os.environ.clear()
         os.environ.update(old_environ)
+
+
+@contextlib.contextmanager
+def unset_env(*environ: str) -> Generator[None, None, None]:
+    """Temporarily unsets the process environment variables.
+
+    This context manager allows you to temporarily unset the process environment variables
+    within a specific scope. It saves the current environment variables, removes the specified
+    ones, and restores the original environment variables when the scope is exited.
+
+    Args:
+        *environ: Names of the environment variables to unset.
+
+    Yields:
+        None
+
+    Examples:
+        >>> with unset_env("PLUGINS_DIR"):
+        ...     "PLUGINS_DIR" in os.environ
+        False
+
+        >>> "PLUGINS_DIR" in os.environ
+        True
+
+    """
+    old_environ = dict(os.environ)
+    for var in environ:
+        os.environ.pop(var, None)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)

--- a/kr8s/tests/test_auth.py
+++ b/kr8s/tests/test_auth.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2026, Kr8s Developers (See LICENSE for list)
 # SPDX-License-Identifier: BSD 3-Clause License
 import base64
+import os
 import ssl
 import sys
 import tempfile
@@ -14,7 +15,7 @@ import kr8s
 from kr8s._async_utils import anext
 from kr8s._auth import KubeAuth
 from kr8s._config import KubeConfig
-from kr8s._testutils import set_env
+from kr8s._testutils import set_env, unset_env
 
 HERE = Path(__file__).parent.resolve()
 
@@ -274,6 +275,36 @@ async def test_service_account(serviceaccount, k8s_token):
     assert api.auth.token == "foo"
 
     (serviceaccount / "token").write_text(k8s_token)
+
+
+async def test_service_account_dns_fallback_no_env_vars(serviceaccount, k8s_token):
+    """When KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are not set,
+    _load_service_account should fall back to kubernetes.default.svc:443."""
+    with unset_env("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT"):
+        auth = KubeAuth(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
+        await auth._load_service_account()
+
+    assert auth.server == "https://kubernetes.default.svc:443"
+    assert auth.token == k8s_token
+
+
+async def test_service_account_dns_fallback_only_host_set(serviceaccount):
+    """When only KUBERNETES_SERVICE_HOST is set, port should default to 443."""
+    with unset_env("KUBERNETES_SERVICE_PORT"):
+        auth = KubeAuth(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
+        await auth._load_service_account()
+
+    assert auth.server.endswith(":443")
+
+
+async def test_service_account_dns_fallback_only_port_set(serviceaccount):
+    """When only KUBERNETES_SERVICE_PORT is set, host should default to kubernetes.default.svc."""
+    with unset_env("KUBERNETES_SERVICE_HOST"):
+        auth = KubeAuth(serviceaccount=serviceaccount, kubeconfig="/no/file/here")
+        await auth._load_service_account()
+
+    port = os.environ["KUBERNETES_SERVICE_PORT"]
+    assert auth.server == f"https://kubernetes.default.svc:{port}"
 
 
 async def test_service_account_with_kubeconfig_namespace(serviceaccount):


### PR DESCRIPTION
Closes #739 

If `enableServiceLinks: false` is set on the Pod where `kr8s` is running it will not be able to authenticate using a service account as it expects the service environment variables to be set.

This PR attempts to fall back to the default Kubernetes DNS for the Kubernetes API if those environment variables are missing. This mimics `kubectl`'s behaviour in this situation.

I also added a new test util which is the inverse of `set_env` called `unset_env` which temporarily removes environment variables within a context manager.