### PR TITLE
add typed overloads for list() raw parameter

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -9,12 +9,7 @@ import re
 import sys
 import time
 from collections.abc import AsyncGenerator, Generator
-from typing import (
-    Any,
-    BinaryIO,
-    Literal,
-    cast,
-)
+from typing import Any, BinaryIO, Literal, cast, overload
 
 import anyio
 import httpx
@@ -919,6 +914,18 @@ class APIObject:
         async for resource in api.async_get(kind=cls, **kwargs):
             if isinstance(resource, dict) or isinstance(resource, cls):
                 yield resource
+
+    @overload
+    @classmethod
+    def list(
+        cls, *, raw: Literal[True], api: Api | None = ..., **kwargs
+    ) -> AsyncGenerator[dict]: ...
+
+    @overload
+    @classmethod
+    def list(
+        cls, *, raw: Literal[False] = False, api: Api | None = ..., **kwargs
+    ) -> AsyncGenerator[Self]: ...
 
     # Must be the last method defined due to https://github.com/python/mypy/issues/17517
     @classmethod


### PR DESCRIPTION
This is tiny change to scratch my itch as I'm using pyrefly as the type checker of my project.

Added two `@overload` signatures keyed on the Literal value of `raw`:
- raw=True  -> AsyncGenerator[dict]   (unparsed API responses)
- raw=False -> AsyncGenerator[Self]   (parsed APIObject instances)

So the autocomplete is improved even for custom API object.
```python
from kr8s.asyncio.objects import Pod, new_class

Custom = new_class("Custom")

async def list_pods() -> list[Pod]:
    return [pod async for pod in Pod.list()]

async def list_pods() -> list[Custom]:
    return [custom async for custom in Custom.list()]
```
