### PR TITLE
fix: avoid BoxKeyError when .status is absent on freshly-created objects

### DIFF
--- a/kr8s/_objects.py
+++ b/kr8s/_objects.py
@@ -198,7 +198,7 @@ class APIObject:
     @property
     def status(self) -> Box:
         """Status of the Kubernetes resource."""
-        return self.raw["status"]
+        return self.raw.get("status", Box())
 
     @status.setter
     def status(self, value: dict) -> None:


### PR DESCRIPTION
When a controller hasn't written .status immediately after creation), calling obj.wait("condition=Ready") raises:

box.exceptions.BoxKeyError: "'status'"

because APIObject.status does a strict Box key access (self.raw["status"]), and _test_conditions calls self.status.get(...) through it.

Fix

Use Box.get() with an empty Box() default so the property is safe to read before .status is populated. The setter is unchanged.

Impact

Any APIObject.wait() call on a resource whose controller writes .status asynchronously was silently flaky (race between obj.wait() starting and the controller's first write). This makes it deterministically safe.


We hit this issue multiple time, when using kr8s to tests certificate creation via cert-manager


